### PR TITLE
fix: only count servers as available if they've been seen at least once

### DIFF
--- a/src/routes/cloud-status/+page.svelte
+++ b/src/routes/cloud-status/+page.svelte
@@ -179,8 +179,10 @@
 				const activeSupportedCount = supportedTypes.filter((id) =>
 					activeServerTypes.some((st) => st.id === id)
 				).length;
+				// Only count as available if it's active AND has been seen available at least once
 				const activeAvailableCount = availableTypes.filter((id) =>
-					activeServerTypes.some((st) => st.id === id)
+					activeServerTypes.some((st) => st.id === id) &&
+					getLastSeenAvailable(location.id, id) !== null
 				).length;
 
 				totalSupported += activeSupportedCount;


### PR DESCRIPTION
Servers showing "Never" (permanently unavailable) were being counted in availability percentage calculations if they appeared in the API's availability array. This fix ensures only servers that have actually been seen available are counted.

Fixes #214