### PR TITLE
fix: exclude never-seen servers from availability percentage calculation

### DIFF
--- a/src/routes/cloud-status/+page.svelte
+++ b/src/routes/cloud-status/+page.svelte
@@ -211,10 +211,13 @@
 					activeServerTypes.some((st) => st.id === id)
 				).length;
 				// Only count as available if it's active AND has been seen available at least once
-				const activeAvailableCount = availableTypes.filter((id) =>
-					activeServerTypes.some((st) => st.id === id) &&
-					getLastSeenAvailable(location.id, id) !== null
-				).length;
+				// We need to check all active supported types, not just those in availableTypes
+				const activeAvailableCount = activeSupportedCount > 0
+					? supportedTypes.filter((id) =>
+							activeServerTypes.some((st) => st.id === id) &&
+							getLastSeenAvailable(location.id, id) !== null
+					  ).length
+					: 0;
 
 				totalSupported += activeSupportedCount;
 				totalAvailable += activeAvailableCount;


### PR DESCRIPTION
The previous fix still counted servers in the availability percentage if they were marked as available by the API, even if they had never been seen. This change ensures that only servers that have actually been seen available (not showing "Never") are counted in the percentage calculation.

Instead of filtering from the availableTypes array, we now filter from supportedTypes and only count those where getLastSeenAvailable returns a non-null value.

Fixes #214