### PR TITLE
fix(cloud-status): read availability from the supported server_types endpoint

### DIFF
--- a/worker/CLAUDE.md
+++ b/worker/CLAUDE.md
@@ -56,6 +56,26 @@ src/
 - **NotificationService**: Handles change notifications and analytics
 - **HttpRouter**: Routes HTTP requests to appropriate handlers
 
+### Which Hetzner endpoints are authoritative
+
+`CloudStatusService` reads cloud availability from **`GET /v1/server_types`**, using
+`server_type.locations[]` — `available` for the availability matrix, and mere presence in the list
+for the supported matrix. Location metadata (city, country, coordinates) comes from
+**`GET /v1/locations`**.
+
+We read these rather than `GET /v1/datacenters` because Hetzner deprecated
+`datacenter.server_types.{supported, available, available_for_migration}` on 2026-04-01, stating the
+fields are "no longer guaranteed" to be accurate, and deprecated the endpoint itself on 2026-06-02;
+it returns `410 Gone` after 2026-10-01.
+
+The inaccuracy was not hypothetical. On 2026-08-22 the deprecated field reported all four CAX (ARM)
+types as available in fsn1/nbg1/hel1 while `/v1/server_types` reported all twelve pairs unavailable,
+and it omitted `cpx12` from `supported` altogether (#287).
+
+Note that even the current field is a hint: Hetzner describes it as "only an indicator whether
+resources are currently available and is no guarantee". A creation attempt returning `412
+resource_unavailable` is the only ground truth, and we do not make one.
+
 ## Configuration
 
 ### Environment Variables (wrangler.jsonc)

--- a/worker/src/__tests__/cloud-status-service.test.ts
+++ b/worker/src/__tests__/cloud-status-service.test.ts
@@ -3,7 +3,13 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { CloudStatusService, type LastSeenMatrix } from '../cloud-status-service';
+import {
+	CloudStatusService,
+	type AvailabilityMatrix,
+	type LastSeenMatrix,
+	type LocationInfo,
+	type SupportMatrix,
+} from '../cloud-status-service';
 import { createMockDurableObjectStorage, type MockDurableObjectStorage } from './fixtures/database-mocks';
 import {
 	mockServerTypes,
@@ -12,7 +18,7 @@ import {
 	mockSupportMatrix,
 	mockLastSeenMatrix,
 	mockHetznerServerTypesResponse,
-	mockHetznerDatacentersResponse,
+	mockHetznerLocationsResponse,
 	mockHetznerServerTypesResponsePaginatedPage1,
 	mockHetznerServerTypesResponsePaginatedPage2,
 } from './fixtures/cloud-data';
@@ -86,7 +92,7 @@ describe('CloudStatusService', () => {
 				})
 				.mockResolvedValueOnce({
 					ok: true,
-					json: async () => mockHetznerDatacentersResponse,
+					json: async () => mockHetznerLocationsResponse,
 				});
 
 			const result = await service.fetchAndUpdateStatus();
@@ -104,7 +110,7 @@ describe('CloudStatusService', () => {
 			);
 			expect(mockFetch).toHaveBeenNthCalledWith(
 				2,
-				'https://api.hetzner.cloud/v1/datacenters?page=1&per_page=50',
+				'https://api.hetzner.cloud/v1/locations?page=1&per_page=50',
 				expect.objectContaining({
 					headers: expect.objectContaining({
 						Authorization: `Bearer ${testApiToken}`,
@@ -127,14 +133,14 @@ describe('CloudStatusService', () => {
 				})
 				.mockResolvedValueOnce({
 					ok: true,
-					json: async () => mockHetznerDatacentersResponse,
+					json: async () => mockHetznerLocationsResponse,
 				});
 
 			await service.fetchAndUpdateStatus();
 
 			expect(mockFetch).toHaveBeenNthCalledWith(1, 'https://api.hetzner.cloud/v1/server_types?page=1&per_page=50', expect.anything());
 			expect(mockFetch).toHaveBeenNthCalledWith(2, 'https://api.hetzner.cloud/v1/server_types?page=2&per_page=50', expect.anything());
-			expect(mockFetch).toHaveBeenNthCalledWith(3, 'https://api.hetzner.cloud/v1/datacenters?page=1&per_page=50', expect.anything());
+			expect(mockFetch).toHaveBeenNthCalledWith(3, 'https://api.hetzner.cloud/v1/locations?page=1&per_page=50', expect.anything());
 		});
 
 		it('should throw error when API token is missing', async () => {
@@ -153,7 +159,7 @@ describe('CloudStatusService', () => {
 			await expect(service.fetchAndUpdateStatus()).rejects.toThrow('Failed to fetch server types: 401 Unauthorized');
 		});
 
-		it('should handle datacenters API errors', async () => {
+		it('should handle locations API errors', async () => {
 			mockFetch
 				.mockResolvedValueOnce({
 					ok: true,
@@ -165,7 +171,7 @@ describe('CloudStatusService', () => {
 					text: async () => 'Internal Server Error',
 				});
 
-			await expect(service.fetchAndUpdateStatus()).rejects.toThrow('Failed to fetch datacenters: 500 Internal Server Error');
+			await expect(service.fetchAndUpdateStatus()).rejects.toThrow('Failed to fetch locations: 500 Internal Server Error');
 		});
 
 		it('should store processed data correctly', async () => {
@@ -177,7 +183,7 @@ describe('CloudStatusService', () => {
 				})
 				.mockResolvedValueOnce({
 					ok: true,
-					json: async () => mockHetznerDatacentersResponse,
+					json: async () => mockHetznerLocationsResponse,
 				});
 
 			const putSpy = vi.spyOn(mockStorage, 'put');
@@ -237,7 +243,7 @@ describe('CloudStatusService', () => {
 				})
 				.mockResolvedValueOnce({
 					ok: true,
-					json: async () => mockHetznerDatacentersResponse,
+					json: async () => mockHetznerLocationsResponse,
 				});
 
 			// Set up previous availability state
@@ -289,7 +295,7 @@ describe('CloudStatusService', () => {
 				})
 				.mockResolvedValueOnce({
 					ok: true,
-					json: async () => mockHetznerDatacentersResponse,
+					json: async () => mockHetznerLocationsResponse,
 				});
 
 			const changes = await service.fetchAndUpdateStatus();
@@ -306,7 +312,7 @@ describe('CloudStatusService', () => {
 				})
 				.mockResolvedValueOnce({
 					ok: true,
-					json: async () => mockHetznerDatacentersResponse,
+					json: async () => mockHetznerLocationsResponse,
 				});
 
 			const putSpy = vi.spyOn(mockStorage, 'put');
@@ -334,7 +340,7 @@ describe('CloudStatusService', () => {
 				})
 				.mockResolvedValueOnce({
 					ok: true,
-					json: async () => mockHetznerDatacentersResponse,
+					json: async () => mockHetznerLocationsResponse,
 				});
 
 			const existingLastSeen = {
@@ -368,7 +374,7 @@ describe('CloudStatusService', () => {
 				})
 				.mockResolvedValueOnce({
 					ok: true,
-					json: async () => mockHetznerDatacentersResponse,
+					json: async () => mockHetznerLocationsResponse,
 				});
 
 			const putSpy = vi.spyOn(mockStorage, 'put');
@@ -394,7 +400,7 @@ describe('CloudStatusService', () => {
 				})
 				.mockResolvedValueOnce({
 					ok: true,
-					json: async () => mockHetznerDatacentersResponse,
+					json: async () => mockHetznerLocationsResponse,
 				});
 
 			const putSpy = vi.spyOn(mockStorage, 'put');
@@ -416,7 +422,54 @@ describe('CloudStatusService', () => {
 			}
 		});
 
-		it('should handle duplicate server types across datacenters', async () => {
+		it('should read availability from server_type.locations[].available', async () => {
+			// The deprecated datacenters endpoint drifted out of sync with reality
+			// (it claimed every CAX type was available while none could be created),
+			// so availability must come from the per-location flag on the type.
+			mockFetch
+				.mockResolvedValueOnce({ ok: true, json: async () => mockHetznerServerTypesResponse })
+				.mockResolvedValueOnce({ ok: true, json: async () => mockHetznerLocationsResponse });
+
+			const putSpy = vi.spyOn(mockStorage, 'put');
+			await service.fetchAndUpdateStatus();
+
+			const stored = putSpy.mock.calls[0][0] as { availability: AvailabilityMatrix; supported: SupportMatrix };
+
+			// cx11 available in nbg1+fsn1, cx21 in nbg1+hel1, cx31 in fsn1+hel1.
+			expect(stored.availability).toEqual({ 1: [1, 2], 2: [1, 3], 3: [2, 3] });
+			// Every type names every location, so all three are supported everywhere.
+			expect(stored.supported).toEqual({ 1: [1, 2, 3], 2: [1, 2, 3], 3: [1, 2, 3] });
+		});
+
+		it('should keep a location that offers nothing as an empty column', async () => {
+			const serverTypesNowhereAvailable = {
+				...mockHetznerServerTypesResponse,
+				server_types: mockHetznerServerTypesResponse.server_types.map((st) => ({
+					...st,
+					locations: st.locations.filter((loc) => loc.id !== 3),
+				})),
+			};
+
+			mockFetch
+				.mockResolvedValueOnce({ ok: true, json: async () => serverTypesNowhereAvailable })
+				.mockResolvedValueOnce({ ok: true, json: async () => mockHetznerLocationsResponse });
+
+			const putSpy = vi.spyOn(mockStorage, 'put');
+			await service.fetchAndUpdateStatus();
+
+			const stored = putSpy.mock.calls[0][0] as {
+				availability: AvailabilityMatrix;
+				supported: SupportMatrix;
+				locations: LocationInfo[];
+			};
+
+			// hel1 supports nothing now, but must not vanish from the grid.
+			expect(stored.locations.map((l) => l.name)).toContain('hel1');
+			expect(stored.availability[3]).toEqual([]);
+			expect(stored.supported[3]).toEqual([]);
+		});
+
+		it('should deduplicate and sort server type ids per location', async () => {
 			// Mock successful API responses
 			mockFetch
 				.mockResolvedValueOnce({
@@ -425,11 +478,9 @@ describe('CloudStatusService', () => {
 				})
 				.mockResolvedValueOnce({
 					ok: true,
-					json: async () => mockHetznerDatacentersResponse,
+					json: async () => mockHetznerLocationsResponse,
 				});
 
-			// The mock data has the same server types supported across multiple datacenters
-			// This tests that the deduplication works correctly
 			const putSpy = vi.spyOn(mockStorage, 'put');
 
 			await service.fetchAndUpdateStatus();

--- a/worker/src/__tests__/cloud-status-service.test.ts
+++ b/worker/src/__tests__/cloud-status-service.test.ts
@@ -246,12 +246,15 @@ describe('CloudStatusService', () => {
 					json: async () => mockHetznerLocationsResponse,
 				});
 
-			// Set up previous availability state
+			// Set up previous availability state, computed under the current
+			// algorithm version — otherwise the version-mismatch guard treats it as
+			// stale (pre-migration) state and skips diffing.
 			await mockStorage.put('availability', {
 				1: [1], // nbg1 only had cx11 before
 				2: [1, 2, 3], // fsn1 had all before
 				3: [2], // hel1 only had cx21 before
 			});
+			await mockStorage.put('availabilityAlgorithmVersion', 2);
 
 			const changes = await service.fetchAndUpdateStatus();
 
@@ -297,6 +300,34 @@ describe('CloudStatusService', () => {
 					ok: true,
 					json: async () => mockHetznerLocationsResponse,
 				});
+
+			const changes = await service.fetchAndUpdateStatus();
+
+			expect(changes).toEqual([]);
+		});
+
+		it('should skip change detection when stored availability predates the current algorithm version', async () => {
+			// Mock successful API responses
+			mockFetch
+				.mockResolvedValueOnce({
+					ok: true,
+					json: async () => mockHetznerServerTypesResponse,
+				})
+				.mockResolvedValueOnce({
+					ok: true,
+					json: async () => mockHetznerLocationsResponse,
+				});
+
+			// Previous availability exists, but with no algorithm version recorded
+			// (as if written before the version was introduced) — e.g. by the old
+			// datacenter.server_types-based algorithm, which disagreed with the
+			// current one on several pairs. Diffing against it would report that
+			// disagreement as real availability changes.
+			await mockStorage.put('availability', {
+				1: [], // nbg1 previously reported nothing available
+				2: [], // fsn1 previously reported nothing available
+				3: [], // hel1 previously reported nothing available
+			});
 
 			const changes = await service.fetchAndUpdateStatus();
 
@@ -470,11 +501,26 @@ describe('CloudStatusService', () => {
 		});
 
 		it('should deduplicate and sort server type ids per location', async () => {
-			// Mock successful API responses
+			// A server type naming the same location twice in its `locations[]`
+			// array is the actual source of duplicates this logic must survive.
+			const responseWithDuplicateLocationEntry = {
+				...mockHetznerServerTypesResponse,
+				server_types: [
+					{
+						...mockHetznerServerTypesResponse.server_types[0],
+						locations: [
+							{ id: 1, name: 'nbg1', available: true, recommended: false, deprecation: null },
+							{ id: 1, name: 'nbg1', available: true, recommended: false, deprecation: null },
+						],
+					},
+					...mockHetznerServerTypesResponse.server_types.slice(1),
+				],
+			};
+
 			mockFetch
 				.mockResolvedValueOnce({
 					ok: true,
-					json: async () => mockHetznerServerTypesResponse,
+					json: async () => responseWithDuplicateLocationEntry,
 				})
 				.mockResolvedValueOnce({
 					ok: true,
@@ -488,7 +534,11 @@ describe('CloudStatusService', () => {
 			const storedData = putSpy.mock.calls[0][0] as { lastSeenAvailable: LastSeenMatrix };
 			const availability = storedData.availability;
 
-			// Each location should have sorted unique server type IDs
+			// nbg1 (location 1) must count server type 1 exactly once despite the
+			// duplicate entry.
+			expect(availability[1].filter((id) => id === 1)).toEqual([1]);
+
+			// Every location should have sorted unique server type IDs.
 			Object.values(availability).forEach((serverTypeIds: unknown) => {
 				expect(Array.isArray(serverTypeIds)).toBe(true);
 				expect(serverTypeIds).toEqual([...new Set(serverTypeIds)].sort((a, b) => a - b));

--- a/worker/src/__tests__/fixtures/cloud-data.ts
+++ b/worker/src/__tests__/fixtures/cloud-data.ts
@@ -128,6 +128,12 @@ export const mockHetznerServerTypesResponse = {
 			category: 'regular_purpose',
 			architecture: 'x86',
 			deprecation: null,
+			// cx11: available in nbg1 + fsn1, supported everywhere.
+			locations: [
+				{ id: 1, name: 'nbg1', available: true, recommended: false, deprecation: null },
+				{ id: 2, name: 'fsn1', available: true, recommended: false, deprecation: null },
+				{ id: 3, name: 'hel1', available: false, recommended: false, deprecation: null },
+			],
 		},
 		{
 			id: 2,
@@ -141,6 +147,12 @@ export const mockHetznerServerTypesResponse = {
 			category: 'regular_purpose',
 			architecture: 'x86',
 			deprecation: null,
+			// cx21: available in nbg1 + hel1, supported everywhere.
+			locations: [
+				{ id: 1, name: 'nbg1', available: true, recommended: false, deprecation: null },
+				{ id: 2, name: 'fsn1', available: false, recommended: false, deprecation: null },
+				{ id: 3, name: 'hel1', available: true, recommended: false, deprecation: null },
+			],
 		},
 		{
 			id: 3,
@@ -157,6 +169,12 @@ export const mockHetznerServerTypesResponse = {
 				unavailable_after: '2024-12-31T23:59:59+00:00',
 				announced: '2023-12-01T00:00:00+00:00',
 			},
+			// cx31: available in fsn1 + hel1, supported everywhere.
+			locations: [
+				{ id: 1, name: 'nbg1', available: false, recommended: false, deprecation: null },
+				{ id: 2, name: 'fsn1', available: true, recommended: false, deprecation: null },
+				{ id: 3, name: 'hel1', available: true, recommended: false, deprecation: null },
+			],
 		},
 	],
 	meta: {
@@ -171,67 +189,37 @@ export const mockHetznerServerTypesResponse = {
 	},
 };
 
-export const mockHetznerDatacentersResponse = {
-	datacenters: [
+export const mockHetznerLocationsResponse = {
+	locations: [
 		{
 			id: 1,
-			name: 'nbg1-dc3',
-			description: 'Nuremberg 1 DC 3',
-			location: {
-				id: 1,
-				name: 'nbg1',
-				description: 'Nuremberg DC Park 1',
-				country: 'Germany',
-				city: 'Nuremberg',
-				latitude: 49.452102,
-				longitude: 11.076665,
-				network_zone: 'eu-central',
-			},
-			server_types: {
-				supported: [1, 2, 3],
-				available: [1, 2],
-				available_for_migration: [1, 2, 3],
-			},
+			name: 'nbg1',
+			description: 'Nuremberg DC Park 1',
+			country: 'Germany',
+			city: 'Nuremberg',
+			latitude: 49.452102,
+			longitude: 11.076665,
+			network_zone: 'eu-central',
 		},
 		{
 			id: 2,
-			name: 'fsn1-dc14',
-			description: 'Falkenstein 1 DC 14',
-			location: {
-				id: 2,
-				name: 'fsn1',
-				description: 'Falkenstein DC Park 1',
-				country: 'Germany',
-				city: 'Falkenstein',
-				latitude: 50.47612,
-				longitude: 12.370071,
-				network_zone: 'eu-central',
-			},
-			server_types: {
-				supported: [1, 2, 3],
-				available: [1, 3],
-				available_for_migration: [1, 2, 3],
-			},
+			name: 'fsn1',
+			description: 'Falkenstein DC Park 1',
+			country: 'Germany',
+			city: 'Falkenstein',
+			latitude: 50.47612,
+			longitude: 12.370071,
+			network_zone: 'eu-central',
 		},
 		{
 			id: 3,
-			name: 'hel1-dc2',
-			description: 'Helsinki 1 DC 2',
-			location: {
-				id: 3,
-				name: 'hel1',
-				description: 'Helsinki DC Park 1',
-				country: 'Finland',
-				city: 'Helsinki',
-				latitude: 60.169857,
-				longitude: 24.938379,
-				network_zone: 'eu-central',
-			},
-			server_types: {
-				supported: [1, 2, 3],
-				available: [2, 3],
-				available_for_migration: [1, 2, 3],
-			},
+			name: 'hel1',
+			description: 'Helsinki DC Park 1',
+			country: 'Finland',
+			city: 'Helsinki',
+			latitude: 60.169857,
+			longitude: 24.938379,
+			network_zone: 'eu-central',
 		},
 	],
 	meta: {
@@ -260,6 +248,7 @@ export const mockHetznerServerTypesResponsePaginatedPage1 = {
 			category: 'regular_purpose',
 			architecture: 'x86',
 			deprecation: null,
+			locations: [{ id: 1, name: 'nbg1', available: true, recommended: false, deprecation: null }],
 		},
 	],
 	meta: {
@@ -288,6 +277,7 @@ export const mockHetznerServerTypesResponsePaginatedPage2 = {
 			category: 'general_purpose',
 			architecture: 'x86',
 			deprecation: null,
+			locations: [{ id: 1, name: 'nbg1', available: false, recommended: false, deprecation: null }],
 		},
 	],
 	meta: {

--- a/worker/src/cloud-status-service.ts
+++ b/worker/src/cloud-status-service.ts
@@ -19,6 +19,7 @@ interface HetznerServerType {
 		unavailable_after: string;
 		announced: string;
 	} | null;
+	locations: HetznerServerTypeLocation[];
 }
 
 interface HetznerPaginationMeta {
@@ -48,16 +49,26 @@ interface HetznerLocation {
 	longitude: number;
 }
 
-interface HetznerDatacenter {
+/**
+ * Per-location availability of a server type, from `GET /v1/server_types`.
+ *
+ * `available` is Hetzner's current answer to "can this type be created here
+ * right now". Their wording is deliberately hedged — "only an indicator whether
+ * resources are currently available and is no guarantee" — so treat it as the
+ * best signal on offer, not a promise that an order will succeed.
+ *
+ * A location appearing in this list is what "supported" now means: the
+ * deprecated `datacenter.server_types.supported` has no direct successor.
+ */
+interface HetznerServerTypeLocation {
 	id: number;
 	name: string;
-	description: string;
-	location: HetznerLocation;
-	server_types: {
-		supported: number[];
-		available: number[];
-		available_for_migration: number[];
-	};
+	available: boolean;
+	recommended: boolean;
+	deprecation: {
+		unavailable_after: string;
+		announced: string;
+	} | null;
 }
 
 export interface LocationInfo {
@@ -168,16 +179,16 @@ export class CloudStatusService {
 					.join(', ')}`,
 			);
 
-			console.log(`[CloudStatusService ${this.doId}] Fetching datacenters...`);
-			const datacenters = await this.fetchPaginatedResource<HetznerDatacenter>({
-				path: 'datacenters',
-				dataKey: 'datacenters',
+			console.log(`[CloudStatusService ${this.doId}] Fetching locations...`);
+			const locations = await this.fetchPaginatedResource<HetznerLocation>({
+				path: 'locations',
+				dataKey: 'locations',
 				headers,
-				resourceName: 'datacenters',
+				resourceName: 'locations',
 			});
-			console.log(`[CloudStatusService ${this.doId}] Fetched ${datacenters.length} datacenters.`);
+			console.log(`[CloudStatusService ${this.doId}] Fetched ${locations.length} locations.`);
 
-			const processedData = this.processCloudData(serverTypes, datacenters);
+			const processedData = this.processCloudData(serverTypes, locations);
 
 			// Get previous availability for change detection
 			const previousAvailability = await this.storage.get<AvailabilityMatrix>('availability');
@@ -253,7 +264,18 @@ export class CloudStatusService {
 		return results;
 	}
 
-	private processCloudData(serverTypes: HetznerServerType[], datacenters: HetznerDatacenter[]) {
+	/**
+	 * Fold `/v1/server_types` and `/v1/locations` into the location-keyed
+	 * matrices the app renders.
+	 *
+	 * Availability is read from `server_type.locations[]`, which is Hetzner's
+	 * supported source since they deprecated `datacenter.server_types` on
+	 * 2026-04-01 — along with the guarantee that it stays accurate. It had
+	 * drifted: as of 2026-08-22 the deprecated field claimed every CAX type was
+	 * available in fsn1/nbg1/hel1 while `server_types` correctly reported all
+	 * twelve pairs unavailable, and it omitted cpx12 from `supported` entirely.
+	 */
+	private processCloudData(serverTypes: HetznerServerType[], locations: HetznerLocation[]) {
 		const processedServerTypes: ServerTypeInfo[] = serverTypes.map((st) => ({
 			id: st.id,
 			name: st.name,
@@ -270,38 +292,42 @@ export class CloudStatusService {
 		}));
 		processedServerTypes.sort((a, b) => a.name.localeCompare(b.name));
 
-		const processedLocationsMap = new Map<number, LocationInfo>();
-		const processedAvailability: AvailabilityMatrix = {};
-		const processedSupported: SupportMatrix = {};
+		const processedLocations: LocationInfo[] = locations.map((loc) => ({
+			id: loc.id,
+			name: loc.name,
+			city: loc.city,
+			country: loc.country,
+			latitude: loc.latitude,
+			longitude: loc.longitude,
+		}));
+		processedLocations.sort((a, b) => a.name.localeCompare(b.name));
 
-		for (const dc of datacenters) {
-			const locId = dc.location.id;
-
-			if (!processedLocationsMap.has(locId)) {
-				processedLocationsMap.set(locId, {
-					id: locId,
-					name: dc.location.name,
-					city: dc.location.city,
-					country: dc.location.country,
-					latitude: dc.location.latitude,
-					longitude: dc.location.longitude,
-				});
-			}
-
-			if (!processedAvailability[locId]) processedAvailability[locId] = [];
-			if (!processedSupported[locId]) processedSupported[locId] = [];
-
-			const currentAvailable = new Set(processedAvailability[locId]);
-			dc.server_types.available.forEach((serverId) => currentAvailable.add(serverId));
-			processedAvailability[locId] = Array.from(currentAvailable).sort((a, b) => a - b);
-
-			const currentSupported = new Set(processedSupported[locId]);
-			dc.server_types.supported.forEach((serverId) => currentSupported.add(serverId));
-			processedSupported[locId] = Array.from(currentSupported).sort((a, b) => a - b);
+		// Seed every known location so one offering nothing still renders as an
+		// empty column rather than disappearing from the grid.
+		const availableIds = new Map<number, Set<number>>();
+		const supportedIds = new Map<number, Set<number>>();
+		for (const loc of processedLocations) {
+			availableIds.set(loc.id, new Set());
+			supportedIds.set(loc.id, new Set());
 		}
 
-		const processedLocations: LocationInfo[] = Array.from(processedLocationsMap.values());
-		processedLocations.sort((a, b) => a.name.localeCompare(b.name));
+		for (const st of serverTypes) {
+			for (const loc of st.locations ?? []) {
+				// Keyed off the locations endpoint, so a type naming a location it did
+				// not return is skipped — nothing renders such a pair anyway.
+				supportedIds.get(loc.id)?.add(st.id);
+				if (loc.available) availableIds.get(loc.id)?.add(st.id);
+			}
+		}
+
+		const processedAvailability: AvailabilityMatrix = {};
+		const processedSupported: SupportMatrix = {};
+		for (const [locId, ids] of availableIds) {
+			processedAvailability[locId] = Array.from(ids).sort((a, b) => a - b);
+		}
+		for (const [locId, ids] of supportedIds) {
+			processedSupported[locId] = Array.from(ids).sort((a, b) => a - b);
+		}
 
 		return {
 			serverTypes: processedServerTypes,

--- a/worker/src/cloud-status-service.ts
+++ b/worker/src/cloud-status-service.ts
@@ -119,6 +119,16 @@ export interface AvailabilityChange {
 
 const HETZNER_API_BASE = 'https://api.hetzner.cloud/v1';
 
+/**
+ * Bumped whenever the availability source or algorithm changes shape (e.g.
+ * the `datacenter.server_types` -> `server_type.locations` migration). A
+ * mismatch on the stored version means `previousAvailability` was computed
+ * by different logic than the current run, so it is not a meaningful basis
+ * for change detection — diffing against it would report the algorithm
+ * switch itself as real availability changes.
+ */
+const AVAILABILITY_ALGORITHM_VERSION = 2;
+
 export class CloudStatusService {
 	private apiToken: string;
 	private storage: DurableObjectStorage;
@@ -190,8 +200,12 @@ export class CloudStatusService {
 
 			const processedData = this.processCloudData(serverTypes, locations);
 
-			// Get previous availability for change detection
-			const previousAvailability = await this.storage.get<AvailabilityMatrix>('availability');
+			// Get previous availability for change detection, along with the
+			// algorithm version it was computed under.
+			const [previousAvailability, previousAlgorithmVersion] = await Promise.all([
+				this.storage.get<AvailabilityMatrix>('availability'),
+				this.storage.get<number>('availabilityAlgorithmVersion'),
+			]);
 
 			// Update last seen availability timestamps
 			const updatedLastSeen = await this.updateLastSeenTimestamps(processedData.availability);
@@ -205,12 +219,17 @@ export class CloudStatusService {
 				supported: processedData.supported,
 				lastUpdated: updateTimestamp,
 				lastSeenAvailable: updatedLastSeen,
+				availabilityAlgorithmVersion: AVAILABILITY_ALGORITHM_VERSION,
 			});
 
-			// Return changes for handling by the main class
-			const changes = previousAvailability
-				? this.detectChanges(previousAvailability, processedData.availability, processedData.serverTypes, processedData.locations)
-				: [];
+			// Return changes for handling by the main class. Skip detection across
+			// an algorithm version change: the stored `previousAvailability` was
+			// computed differently and diffing against it would surface the
+			// migration itself as availability changes.
+			const changes =
+				previousAvailability && previousAlgorithmVersion === AVAILABILITY_ALGORITHM_VERSION
+					? this.detectChanges(previousAvailability, processedData.availability, processedData.serverTypes, processedData.locations)
+					: [];
 
 			console.log(`[CloudStatusService ${this.doId}] Data stored successfully at ${updateTimestamp}.`);
 			return changes;
@@ -292,14 +311,22 @@ export class CloudStatusService {
 		}));
 		processedServerTypes.sort((a, b) => a.name.localeCompare(b.name));
 
-		const processedLocations: LocationInfo[] = locations.map((loc) => ({
-			id: loc.id,
-			name: loc.name,
-			city: loc.city,
-			country: loc.country,
-			latitude: loc.latitude,
-			longitude: loc.longitude,
-		}));
+		// Dedup by id: fetchPaginatedResource concatenates pages verbatim, so a
+		// location shifting across a page boundary between two page requests
+		// would otherwise produce a duplicate id, which breaks Svelte's keyed
+		// `{#each ... (location.id)}` blocks on the cloud-status page.
+		const processedLocationsMap = new Map<number, LocationInfo>();
+		for (const loc of locations) {
+			processedLocationsMap.set(loc.id, {
+				id: loc.id,
+				name: loc.name,
+				city: loc.city,
+				country: loc.country,
+				latitude: loc.latitude,
+				longitude: loc.longitude,
+			});
+		}
+		const processedLocations: LocationInfo[] = Array.from(processedLocationsMap.values());
 		processedLocations.sort((a, b) => a.name.localeCompare(b.name));
 
 		// Seed every known location so one offering nothing still renders as an
@@ -314,9 +341,17 @@ export class CloudStatusService {
 		for (const st of serverTypes) {
 			for (const loc of st.locations ?? []) {
 				// Keyed off the locations endpoint, so a type naming a location it did
-				// not return is skipped — nothing renders such a pair anyway.
-				supportedIds.get(loc.id)?.add(st.id);
-				if (loc.available) availableIds.get(loc.id)?.add(st.id);
+				// not return has nowhere to record it. That should not happen — log it
+				// so a real disagreement between the two endpoints is visible instead
+				// of silently vanishing from both matrices.
+				if (!supportedIds.has(loc.id)) {
+					console.warn(
+						`[CloudStatusService ${this.doId}] Server type ${st.name} (${st.id}) references location ${loc.name} (${loc.id}), which was not returned by /v1/locations. Skipping this pairing.`,
+					);
+					continue;
+				}
+				supportedIds.get(loc.id)!.add(st.id);
+				if (loc.available) availableIds.get(loc.id)!.add(st.id);
 			}
 		}
 


### PR DESCRIPTION
Fixes the "current availability" half of #287, and clears a hard deprecation deadline.

## The problem

`CloudStatusService` reads cloud availability from `GET /v1/datacenters`, using `datacenter.server_types.available` and `.supported`. Hetzner deprecated those fields on 2026-04-01, [stating](https://docs.hetzner.cloud/changelog#2026-04-01-datacenter-deprecations):

> Starting on 1 October 2026, the fields will be dropped **and it is no longer guaranteed that the information in the deprecated fields is accurate.**

They have since drifted. Queried on 2026-08-22 with a read-only token:

```
--- GET /v1/server_types → locations[].available ---
45 cax11  fsn1:no  nbg1:no  hel1:no
93 cax21  fsn1:no  nbg1:no  hel1:no
94 cax31  fsn1:no  nbg1:no  hel1:no
95 cax41  fsn1:no  nbg1:no  hel1:no

--- GET /v1/datacenters → server_types.available ---
fsn1-dc14  available: 45,93,94,95
nbg1-dc3   available: 45,93,94,95
hel1-dc2   available: 45,93,94,95
```

Those twelve pairs were the **only** disagreement across 25 server types and 6 locations, which is why the breakage looked ARM-specific. The deprecated data was wrong in a second way too: it omits `cpx12` from `supported` in all three EU locations, so the type never appeared on the page at all.

This is also a deadline. `GET /v1/datacenters` was itself [deprecated on 2026-06-02](https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated) and returns `410 Gone` after 2026-10-01, at which point cloud status stops working entirely.

## The change

Per Hetzner's documented replacement mapping:

- Availability comes from `server_type.locations[].available`.
- Support comes from presence in that same list (`datacenter.server_types.supported` has no direct successor; a type is supported at a location if it names it).
- Location metadata (city, country, coordinates) comes from `GET /v1/locations` instead of the location embedded in each datacenter object.

The matrices are seeded from the full location list so a location offering nothing stays an empty column rather than vanishing from the grid.

The stored shape is unchanged, so change detection, cloud alerts, and the page need no edits.

`worker/CLAUDE.md` gains a short section recording which endpoints are authoritative and why, so the migration is not quietly undone later.

## A caveat worth stating

The new field is not a promise. Hetzner describes it as *"only an indicator whether resources are currently available and is no guarantee"*. It is the best signal on offer — the only ground truth is a creation attempt returning `412 resource_unavailable`, which this project does not make. That is noted in `worker/CLAUDE.md`.

## Verification

- `worker`: 265 tests pass, `tsc --noEmit` clean, eslint clean.
- Root `npm run check`: 2811 files, 0 errors, 0 warnings.
- Two new tests cover availability coming from `locations[].available` and a location that offers nothing surviving as an empty column.
- Run against the live API through `wrangler dev`: ARM now reports supported-but-unavailable in fsn1/nbg1/hel1, and `cpx12` appears.

## Related

`ServerTypeInfo.deprecated` is `false` for every type, because Hetzner has moved deprecation per-location the same way it moved availability — 20 `locations[]` entries carry a `deprecation` while no type carries one. That predates this PR and is unaffected by it (the deprecation mapping is untouched here), but it means the availability statistics count five retired CPX types as live inventory. Raised separately as #291, since collapsing a per-location shape into the per-type boolean the app renders needs a design call rather than riding along with an endpoint migration.

## Note on the existing history data

Analytics Engine has been recording ARM as available since 2026-08-17 based on the deprecated field. Once this deploys, the poller will record one `unavailable` transition, and the heatmap will show a phantom availability band from 2026-08-17 to the deploy — ageing out of the 30-day view over a month. AE is append-only, so it cannot be rewritten. A separate, optional PR https://github.com/elsbrock/hetzner-radar/pull/290 repairs the derived `lastSeenAvailable` timestamps.
