### PR TITLE
fix(cloud-status): resolve the availability history seed without the live snapshot

### DIFF
--- a/src/lib/availability-history.test.ts
+++ b/src/lib/availability-history.test.ts
@@ -89,6 +89,17 @@ describe("resolveSeed", () => {
     expect(resolveSeed({})).toBe(false);
     expect(resolveSeed({ fromSnapshot: null })).toBe(false);
   });
+
+  it("should treat a null resolved transition as absent, not as unavailable", () => {
+    // `fromHistory` follows the module's `boolean | null` idiom, so null means
+    // "the query found nothing" and must fall through rather than seed false.
+    expect(
+      resolveSeed({
+        fromHistory: null,
+        firstEvent: { t: 1_000, up: false },
+      }),
+    ).toBe(true);
+  });
 });
 
 describe("a window whose seed predates Analytics Engine retention", () => {

--- a/src/lib/availability-history.test.ts
+++ b/src/lib/availability-history.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { availableFraction, bucketAvailability } from "./availability-history";
+import {
+  availableFraction,
+  bucketAvailability,
+  resolveSeed,
+} from "./availability-history";
 
 const HOUR = 3_600_000;
 
@@ -50,6 +54,69 @@ describe("availableFraction", () => {
       { t: 0.7 * HOUR, up: false },
     ];
     expect(availableFraction(points, 0, HOUR, windowEnd)).toBeCloseTo(0.3, 10);
+  });
+});
+
+describe("resolveSeed", () => {
+  it("should prefer the transition resolved from before the window", () => {
+    expect(
+      resolveSeed({
+        fromHistory: false,
+        firstEvent: { t: 0, up: false },
+        fromSnapshot: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("should invert the first in-window transition when no seed was found", () => {
+    // cax21/fsn1: unavailable since May, so the seed query found nothing within
+    // its lookback, and the only event in the 30d window is "became available".
+    // Trusting the snapshot here painted the whole month green (#287).
+    expect(
+      resolveSeed({
+        firstEvent: { t: 1_000, up: true },
+        fromSnapshot: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("should fall back to the snapshot only for a window with no transitions", () => {
+    expect(resolveSeed({ fromSnapshot: true })).toBe(true);
+    expect(resolveSeed({ fromSnapshot: false })).toBe(false);
+  });
+
+  it("should assume unavailable when nothing is known", () => {
+    expect(resolveSeed({})).toBe(false);
+    expect(resolveSeed({ fromSnapshot: null })).toBe(false);
+  });
+});
+
+describe("a window whose seed predates Analytics Engine retention", () => {
+  it("should stay unavailable until the transition that made it available", () => {
+    // The #287 shape: a 30-day window over a pair that went unavailable months
+    // earlier (so the seed query returns nothing) and became available a third
+    // of the way in. Everything before that transition must read unavailable.
+    const stepMs = HOUR;
+    const seedStart = 0;
+    const windowEnd = 30 * HOUR;
+    const becameAvailable = 10 * HOUR;
+
+    const values = bucketAvailability({
+      buckets: buckets(seedStart, stepMs, 30),
+      stepMs,
+      seedStart,
+      windowEnd,
+      seed: resolveSeed({
+        fromHistory: undefined,
+        firstEvent: { t: becameAvailable, up: true },
+        fromSnapshot: true, // the live snapshot: available *now*
+      }),
+      events: [{ t: becameAvailable, up: true }],
+      reconcileTo: true,
+    });
+
+    expect(values.slice(0, 10)).toEqual(Array(10).fill(0));
+    expect(values.slice(10)).toEqual(Array(20).fill(1));
   });
 });
 

--- a/src/lib/availability-history.ts
+++ b/src/lib/availability-history.ts
@@ -6,8 +6,8 @@
  * means replaying those edges as a step function rather than reading samples.
  * The subtleties that make this worth isolating (and testing):
  *
- * - the state entering the window comes from outside it, so it must be supplied
- *   rather than guessed from the window's own first edge;
+ * - the state entering the window comes from outside it, so it has to be
+ *   resolved deliberately (see `resolveSeed`) rather than assumed;
  * - a bucket is usually only partly available, so cells carry an occupancy
  *   fraction rather than a boolean.
  */
@@ -39,6 +39,45 @@ export interface BucketAvailabilityOptions {
    * consistent with a snapshot in either state and is left as measured.
    */
   reconcileTo?: boolean | null;
+}
+
+export interface SeedResolutionOptions {
+  /**
+   * State established by the last transition *before* the window, when the
+   * history query found one. Authoritative whenever it is present.
+   */
+  fromHistory?: boolean;
+  /**
+   * Earliest transition inside the window, if the window holds any.
+   */
+  firstEvent?: AvailabilityChangePoint;
+  /**
+   * State from the live snapshot, or `null` when no snapshot covers this row
+   * (or the window being rendered is not the live one).
+   */
+  fromSnapshot?: boolean | null;
+}
+
+/**
+ * The state a window opens in, in descending order of authority.
+ *
+ * 1. The transition resolved from before the window — it says so directly.
+ * 2. Otherwise the inverse of the window's first transition. The dataset holds
+ *    only genuine state *changes*, so "the first thing that happened here was
+ *    becoming available" can only mean the window opened unavailable.
+ * 3. Otherwise the live snapshot. With no transition either side of the window
+ *    boundary, nothing has changed and the snapshot is exactly that unchanged
+ *    state. This is the *last* resort: reaching for it while the window does
+ *    hold transitions paints the state *after* them across everything before,
+ *    which is how a pair unavailable since May rendered as available all month.
+ * 4. Otherwise unavailable, rather than inventing uptime.
+ */
+export function resolveSeed(options: SeedResolutionOptions): boolean {
+  const { fromHistory, firstEvent, fromSnapshot = null } = options;
+
+  if (fromHistory !== undefined) return fromHistory;
+  if (firstEvent) return !firstEvent.up;
+  return fromSnapshot ?? false;
 }
 
 /**

--- a/src/lib/availability-history.ts
+++ b/src/lib/availability-history.ts
@@ -43,10 +43,10 @@ export interface BucketAvailabilityOptions {
 
 export interface SeedResolutionOptions {
   /**
-   * State established by the last transition *before* the window, when the
-   * history query found one. Authoritative whenever it is present.
+   * State established by the last transition *before* the window, or `null`
+   * when the history query found none. Authoritative whenever it is present.
    */
-  fromHistory?: boolean;
+  fromHistory?: boolean | null;
   /**
    * Earliest transition inside the window, if the window holds any.
    */
@@ -65,6 +65,13 @@ export interface SeedResolutionOptions {
  * 2. Otherwise the inverse of the window's first transition. The dataset holds
  *    only genuine state *changes*, so "the first thing that happened here was
  *    becoming available" can only mean the window opened unavailable.
+ *
+ *    This is the inference 4ad2595 removed, reinstated as a *fallback* rather
+ *    than the primary mechanism. Its caveat still stands: it holds only while
+ *    edges strictly alternate. `detectChanges` compares sets, so they should —
+ *    but the Analytics Engine write swallows failures, and a dropped edge would
+ *    leave two in the same direction and invert this the wrong way. A grounded
+ *    guess still beats reaching for the snapshot, which fails outright (#287).
  * 3. Otherwise the live snapshot. With no transition either side of the window
  *    boundary, nothing has changed and the snapshot is exactly that unchanged
  *    state. This is the *last* resort: reaching for it while the window does
@@ -73,9 +80,9 @@ export interface SeedResolutionOptions {
  * 4. Otherwise unavailable, rather than inventing uptime.
  */
 export function resolveSeed(options: SeedResolutionOptions): boolean {
-  const { fromHistory, firstEvent, fromSnapshot = null } = options;
+  const { fromHistory = null, firstEvent, fromSnapshot = null } = options;
 
-  if (fromHistory !== undefined) return fromHistory;
+  if (fromHistory !== null) return fromHistory;
   if (firstEvent) return !firstEvent.up;
   return fromSnapshot ?? false;
 }

--- a/src/lib/components/CloudAvailabilityChart.svelte
+++ b/src/lib/components/CloudAvailabilityChart.svelte
@@ -340,15 +340,29 @@
 
 		const out: MatrixDatum[] = [];
 		for (const [id, row] of ordered) {
-			const rowEvents = (events.get(id) ?? []).slice().sort((p, q) => p.t - q.t);
+			const rowEvents = events.get(id) ?? [];
+			// Scanned rather than sorted: `bucketAvailability` sorts its own copy, and
+			// its contract says events need not arrive ordered, so picking `[0]` would
+			// couple the seed to a guarantee the module disclaims.
+			let firstEvent: { t: number; up: boolean } | undefined;
+			for (const e of rowEvents) if (!firstEvent || e.t < firstEvent.t) firstEvent = e;
+
 			const values = bucketAvailability({
 				buckets: starts,
 				stepMs,
 				seedStart,
 				windowEnd,
 				seed: resolveSeed({
-					fromHistory: seeds.get(id),
-					firstEvent: rowEvents[0],
+					fromHistory: seeds.get(id) ?? null,
+					firstEvent,
+					// Not gated on `isLiveWindow`, unlike `reconcileTo` below. This is
+					// only reached when the dataset held nothing at all across the seed
+					// lookback *and* the window, so both remaining options are guesses:
+					// the snapshot, or "unavailable". A pair that actually changed would
+					// have left edges, so the snapshot is the better-calibrated one — a
+					// stable, long-available type would otherwise render solid red across
+					// a paged-back window. The honest fix is to render "unknown" as its
+					// own state, which needs a legend decision, not a seeding rule.
 					fromSnapshot: row.snapshotKnown ? row.currentlyAvailable : null
 				}),
 				events: rowEvents,

--- a/src/lib/components/CloudAvailabilityChart.svelte
+++ b/src/lib/components/CloudAvailabilityChart.svelte
@@ -13,7 +13,7 @@
 	import 'chartjs-adapter-date-fns';
 	import { MatrixController, MatrixElement } from 'chartjs-chart-matrix';
 	import { onDestroy } from 'svelte';
-	import { bucketAvailability } from '$lib/availability-history';
+	import { bucketAvailability, resolveSeed } from '$lib/availability-history';
 
 	Chart.register(MatrixController, MatrixElement, CategoryScale, TimeScale, LinearScale, Tooltip);
 
@@ -340,18 +340,18 @@
 
 		const out: MatrixDatum[] = [];
 		for (const [id, row] of ordered) {
+			const rowEvents = (events.get(id) ?? []).slice().sort((p, q) => p.t - q.t);
 			const values = bucketAvailability({
 				buckets: starts,
 				stepMs,
 				seedStart,
 				windowEnd,
-				// State entering the window, in order of authority: the seed resolved
-				// from the last transition before the window; else — meaning the pair
-				// has not changed state within the seed lookback — the live snapshot,
-				// which is exactly that unchanged state. If neither is known, assume
-				// unavailable rather than inventing uptime.
-				seed: seeds.get(id) ?? (row.snapshotKnown ? row.currentlyAvailable : false),
-				events: events.get(id) ?? [],
+				seed: resolveSeed({
+					fromHistory: seeds.get(id),
+					firstEvent: rowEvents[0],
+					fromSnapshot: row.snapshotKnown ? row.currentlyAvailable : null
+				}),
+				events: rowEvents,
 				// Only the live window can be checked against the live snapshot; older
 				// windows describe the past.
 				reconcileTo: isLiveWindow && row.snapshotKnown ? row.currentlyAvailable : null

--- a/worker/src/__tests__/analytics-query-service.test.ts
+++ b/worker/src/__tests__/analytics-query-service.test.ts
@@ -102,9 +102,9 @@ describe('AnalyticsQueryService', () => {
 			const sql = seedSql();
 			expect(sql).toContain('argMax(double1, timestamp) as availability');
 			expect(sql).toContain('GROUP BY blob1, blob2');
-			// Strictly before the window start, looking back 30 days.
+			// Strictly before the window start, looking back 92 days (Analytics Engine's retention).
 			expect(sql).toContain("timestamp < toDateTime('2026-07-01T00:00:00')");
-			expect(sql).toContain("timestamp >= toDateTime('2026-06-01T00:00:00')");
+			expect(sql).toContain("timestamp >= toDateTime('2026-03-31T00:00:00')");
 		});
 
 		it('should mark seed points and stamp them at the window start', async () => {

--- a/worker/src/analytics-query-service.ts
+++ b/worker/src/analytics-query-service.ts
@@ -84,10 +84,18 @@ const MAX_EVENT_ROWS = 10000;
 
 /**
  * How far back to look for the transition that established the state entering
- * the window. Analytics Engine retains three months, so this stays well inside
- * retention while bounding the scan.
+ * the window.
+ *
+ * This is Analytics Engine's full three-month retention, deliberately: a scarce
+ * pair can sit in one state for months, and a shorter lookback silently reports
+ * "no seed" for exactly those pairs. At 30 days, cax21/fsn1 — unavailable since
+ * 2026-05-26 — produced no seed for a 30-day window, and the client fell back to
+ * the live snapshot and painted the whole month available (#287).
+ *
+ * A pair whose last change predates retention still yields no row; the client
+ * resolves that case from the window's own first transition instead.
  */
-const SEED_LOOKBACK_MS = 30 * 24 * 60 * 60 * 1000;
+const SEED_LOOKBACK_MS = 92 * 24 * 60 * 60 * 1000;
 
 export class AnalyticsQueryService {
 	constructor() {
@@ -107,11 +115,11 @@ export class AnalyticsQueryService {
 	 *    twice inside one bucket, so a short availability blip renders as
 	 *    "available ever since". Raw rows with their true timestamps are returned
 	 *    instead.
-	 * 2. **An explicit seed.** A consumer cannot infer the state entering the
-	 *    window from the window's own events (inverting the first event only works
-	 *    while edges strictly alternate). A second query resolves the last
-	 *    transition *before* `startDate` per pair and returns it as a synthetic
-	 *    point stamped at `startDate` with `seed: true`.
+	 * 2. **An explicit seed.** The state entering the window comes from outside
+	 *    it, so a second query resolves the last transition *before* `startDate`
+	 *    per pair and returns it as a synthetic point stamped at `startDate` with
+	 *    `seed: true`. It looks back across the whole retention window, since a
+	 *    scarce pair can hold one state for months.
 	 */
 	async queryAvailabilityHistory(
 		options: AnalyticsQueryOptions,

--- a/worker/src/analytics-query-service.ts
+++ b/worker/src/analytics-query-service.ts
@@ -86,11 +86,17 @@ const MAX_EVENT_ROWS = 10000;
  * How far back to look for the transition that established the state entering
  * the window.
  *
- * This is Analytics Engine's full three-month retention, deliberately: a scarce
- * pair can sit in one state for months, and a shorter lookback silently reports
- * "no seed" for exactly those pairs. At 30 days, cax21/fsn1 — unavailable since
- * 2026-05-26 — produced no seed for a 30-day window, and the client fell back to
- * the live snapshot and painted the whole month available (#287).
+ * This is Analytics Engine's full retention, deliberately: a scarce pair can sit
+ * in one state for months, and a shorter lookback silently reports "no seed" for
+ * exactly those pairs. At 30 days, cax21/fsn1 — unavailable since 2026-05-26 —
+ * produced no seed for a 30-day window, and the client fell back to the live
+ * snapshot and painted the whole month available (#287).
+ *
+ * Retention is documented as "three months" rather than a day count, so 92 is
+ * the longest three consecutive calendar months (31 + 31 + 30) and never falls
+ * short of it. Scanning past retention costs nothing — there are no rows there —
+ * and the query is aggregated to one row per pair, so neither the response nor
+ * the bill grows with the range. Analytics Engine bills per query, not per row.
  *
  * A pair whose last change predates retention still yields no row; the client
  * resolves that case from the window's own first transition instead.


### PR DESCRIPTION
Fixes the "historical availability" half of #287. Independent of #288 — no overlapping files — though the two together are what make the ARM rows read correctly.

## The problem

The 30-day heatmap showed `cax21`/`fsn1` as available for the entire window, while the pair had in fact been unavailable since May. Both the events query and the seed query are working correctly; the fault is in what the client does when the seed query returns nothing.

Queried against production for the **90-day** window, the record is exactly right:

```
2026-05-24T10:32:28Z [SEED] DOWN
2026-05-24 13:07:03  UP     2026-05-24 13:26:10  DOWN
2026-05-24 17:25:43  UP     2026-05-24 17:56:55  DOWN
2026-05-26 12:58:20  UP     2026-05-26 13:26:33  DOWN
2026-08-17 09:27:31  UP     ← still up
```

The **30-day** window returns only `2026-08-17 09:27:31 UP`, and no seed row. Two defects compound:

1. **The seed lookback was too short.** `SEED_LOOKBACK_MS` was 30 days, so the query searched 2026-06-23 → 2026-07-23 for the transition establishing the window's opening state. The real one is 2026-05-26 — 58 days back. Analytics Engine retains three months, so two thirds of the available history was being discarded.

2. **The no-seed fallback reached for the live snapshot.** With no seed row, `CloudAvailabilityChart` used `row.currentlyAvailable`. The comment justified this as "the pair has not changed state within the lookback, so the snapshot *is* that unchanged state" — but that only holds when the window contains no transitions either. Here it contained one, so the state *after* it was painted across the seven weeks before it. Green for the whole month.

## The change

- `SEED_LOOKBACK_MS` → 92 days, matching Analytics Engine's retention. This one is worth a section of its own, below.
- Extract the seed decision into `resolveSeed` in `$lib/availability-history`, alongside the bucketing rules it belongs with, in descending order of authority:
  1. the transition resolved from before the window;
  2. otherwise **the inverse of the window's own first transition** — `cloud_availability_v2` stores only genuine state *changes* (see `NotificationService.writeToAnalyticsEngine`), so "the first thing that happened was becoming available" proves it was not available before;
  3. otherwise the live snapshot, now correctly the last resort rather than the second;
  4. otherwise unavailable, rather than inventing uptime.

Step 2 is what makes this robust past retention, where no lookback can help.

**Step 2 does reinstate the inference 4ad2595 removed**, demoted from primary mechanism to fallback, and that commit's caveat still applies: inverting the first edge is sound only while edges strictly alternate. `detectChanges` compares sets so they should, but `NotificationService` swallows Analytics Engine write failures, and a dropped edge would leave two in the same direction and invert this the wrong way. The judgement here is that a grounded guess beats reaching for the live snapshot, which fails outright in the reported case — but it is a judgement, and worth your eye.

The seed query stays authoritative; inversion only covers the case where it legitimately has nothing to say.

## Why the seed lookback goes to 92 days

This is the change most likely to raise an eyebrow, so: what it is, why it is necessary, why 92, and what it costs.

**It is not a tuning tweak — 30 days structurally cannot work.** The seed query answers "what state did this window open in?" by finding the last transition *before* the window. `cax21`/`fsn1` last changed on 2026-05-26. A 30-day window opening on 2026-07-23 searched back only to 2026-06-23 and found nothing, so the client fell through to the live snapshot and painted the month green. Any lookback shorter than the gap between transitions fails the same way, and scarce types — the ones people actually watch this page for — are precisely the ones that sit unchanged for months. The fix has to reach as far back as the data goes.

**Why 92 specifically.** Analytics Engine retention is [documented as "three months"](https://developers.cloudflare.com/analytics/analytics-engine/limits/) rather than a day count. 92 days is the longest three consecutive calendar months (31 + 31 + 30), so it never falls short of retention regardless of where in the year the window sits. Reaching past retention costs nothing — there are simply no rows there — whereas falling short reintroduces the bug.

Probed against production on 2026-08-22, the wall is real and sits almost exactly there. Queries for one location over increasing windows:

```
window   92d →  3405 rows | oldest 2026-05-22 (92.0d ago)
window  120d →  3424 rows | oldest 2026-05-22 (92.5d ago)
window  180d →  3424 rows | oldest 2026-05-22 (92.5d ago)
window  365d →  3424 rows | oldest 2026-05-22 (92.5d ago)
window  730d →  3424 rows | oldest 2026-05-22 (92.5d ago)
```

A two-year request returns nothing older than 92.5 days, and at 3,424 rows the 10,000-row cap is not in play — a real boundary, not truncation. So 92 is not conservative rounding; it is within half a day of everything that exists, and a larger number would buy nothing.

**Nothing about the page changed.** The ranges are still 24h/7d/30d. The events query still fetches exactly the displayed range. The only thing that moved is the lower bound of the *seed* query's `WHERE` clause; the diff touches four files and none of them is the page.

**It does not load 90 days of data.** The seed query is aggregated:

```sql
SELECT blob1, blob2, argMax(...) FROM cloud_availability_v2
WHERE timestamp >= … AND timestamp < startDate GROUP BY blob1, blob2
```

It returns **one row per (server type × location)** however far back it scans, so the response is the same size it was.

**It does not cost more.** Analytics Engine [bills per query](https://developers.cloudflare.com/analytics/analytics-engine/pricing/), not per row or byte — *"no extra cost for more or less complex queries, and no extra cost for reading only a few rows of data versus many rows"* — and the query count is unchanged at two per chart render (seed + events). Workers Paid includes 1M read queries/month.

**What does grow is scan volume, which is latency only.** Measured against production on the worst case, a whole location with no server-type filter:

| seed lookback | rows scanned |
|---|---|
| 30d | 836 |
| 92d | 3,408 |

The chart does not poll — no interval, no `invalidateAll`; it fetches when opened and on each range toggle or page step — so this is a handful of queries per session, on an aggregation returning six-ish rows.

## Effect on the reported case

Real production transitions for `cax21`/`fsn1`, replayed through the actual module over the live 30-day window (`.` = unavailable, `#` = available):

```
events in window: 2026-08-17T09:27=UP     seed row from query: (none)
window: 2026-07-23 -> 2026-08-22

main (snapshot fallback)   ###################################################################################.
this PR (resolveSeed)      .....................................................................~#############.
```

## Follow-up commits

Two commits follow the fix, neither changing behaviour.

The first addresses review: the docs now state the 4ad2595 relationship plainly; the `fromSnapshot`/`reconcileTo` liveness asymmetry is explained in place rather than left to look accidental; the earliest transition is found by scan rather than sorting a copy `bucketAvailability` sorts again; and `fromHistory` follows the module's existing `boolean | null` idiom instead of using `undefined` for absence.

The second records the reasoning for the 92-day lookback on `SEED_LOOKBACK_MS` itself, so whoever reads that constant later gets the retention argument without having to find this PR.

## Verification

- Root `npm run check`: 2811 files, 0 errors, 0 warnings. 253 frontend tests pass; worker `tsc --noEmit` and eslint clean.
- Six new tests: five on `resolveSeed`'s precedence — the four ranks, plus one pinning that a `null` resolved transition means "absent" and falls through rather than seeding unavailable — and a regression test replaying the exact #287 shape — a 30-bucket window, no seed, one "became available" transition a third of the way in, and a snapshot saying available — asserting the first ten buckets read unavailable. That test fails on `main`.

