### PR TITLE
fix(cloud-status): repair the ARM last-seen timestamps the deprecated field wrote

### DIFF
--- a/worker/src/__tests__/arm-last-seen-repair.test.ts
+++ b/worker/src/__tests__/arm-last-seen-repair.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Tests for the one-off ARM `lastSeenAvailable` repair.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ARM_SUSPECT_SINCE, findSuspectKeys, recoverLastSeen, repairLastSeen, type RecoveryEvent } from '../arm-last-seen-repair';
+import type { AvailabilityMatrix, LastSeenMatrix, ServerTypeInfo } from '../cloud-status-service';
+
+function serverType(id: number, name: string, architecture: string): ServerTypeInfo {
+	return {
+		id,
+		name,
+		description: name.toUpperCase(),
+		cores: 4,
+		memory: 8,
+		disk: 80,
+		cpu_type: 'shared',
+		architecture,
+		category: 'cost_optimized',
+		storageType: 'local',
+		isDeprecated: false,
+		deprecated: false,
+	};
+}
+
+const SERVER_TYPES = [serverType(93, 'cax21', 'arm'), serverType(95, 'cax41', 'arm'), serverType(22, 'cx22', 'x86')];
+
+describe('findSuspectKeys', () => {
+	const availability: AvailabilityMatrix = { 1: [22], 2: [] };
+
+	it('should select ARM entries stamped inside the suspect window', () => {
+		const lastSeen: LastSeenMatrix = {
+			'1-93': '2026-08-22T10:00:00.000Z',
+			'2-95': '2026-08-20T10:00:00.000Z',
+		};
+
+		expect(findSuspectKeys(lastSeen, SERVER_TYPES, availability).sort()).toEqual(['1-93', '2-95']);
+	});
+
+	it('should leave entries that predate the suspect window alone', () => {
+		const lastSeen: LastSeenMatrix = { '1-93': '2026-05-26T13:26:33.000Z' };
+
+		expect(findSuspectKeys(lastSeen, SERVER_TYPES, availability)).toEqual([]);
+	});
+
+	it('should ignore x86 types, which the deprecated field reported correctly', () => {
+		const lastSeen: LastSeenMatrix = { '1-22': '2026-08-22T10:00:00.000Z' };
+
+		expect(findSuspectKeys(lastSeen, SERVER_TYPES, availability)).toEqual([]);
+	});
+
+	it('should leave a pair that is genuinely available now alone', () => {
+		// Its timestamp is "now" and correct, whatever wrote it.
+		const lastSeen: LastSeenMatrix = { '1-93': '2026-08-22T10:00:00.000Z' };
+
+		expect(findSuspectKeys(lastSeen, SERVER_TYPES, { 1: [93] })).toEqual([]);
+	});
+});
+
+describe('recoverLastSeen', () => {
+	const events: RecoveryEvent[] = [
+		{ timestamp: ARM_SUSPECT_SINCE, serverTypeId: 93, locationId: 1, available: false, seed: true },
+		{ timestamp: '2026-05-24 13:07:03', serverTypeId: 93, locationId: 1, available: true },
+		{ timestamp: '2026-05-24 13:26:10', serverTypeId: 93, locationId: 1, available: false },
+		{ timestamp: '2026-05-26 12:58:20', serverTypeId: 93, locationId: 1, available: true },
+		{ timestamp: '2026-05-26 13:26:33', serverTypeId: 93, locationId: 1, available: false },
+		{ timestamp: '2026-08-17 09:27:31', serverTypeId: 93, locationId: 1, available: true },
+	];
+
+	it('should take the last unavailable transition before the suspect window', () => {
+		expect(recoverLastSeen(events)).toEqual({ '1-93': '2026-05-26T13:26:33.000Z' });
+	});
+
+	it('should ignore the bogus run and the corrective transition after it', () => {
+		const withCorrection: RecoveryEvent[] = [
+			...events,
+			{ timestamp: '2026-08-22 11:00:00', serverTypeId: 93, locationId: 1, available: false },
+		];
+
+		// Not 2026-08-22: that is the poller recording the fix, not real availability.
+		expect(recoverLastSeen(withCorrection)).toEqual({ '1-93': '2026-05-26T13:26:33.000Z' });
+	});
+
+	it('should return nothing for a pair whose last change predates retention', () => {
+		expect(recoverLastSeen([{ timestamp: '2026-08-17 09:27:31', serverTypeId: 94, locationId: 3, available: true }])).toEqual({});
+	});
+
+	it('should treat Analytics Engine timestamps as UTC', () => {
+		const recovered = recoverLastSeen([{ timestamp: '2026-05-26 13:26:33', serverTypeId: 93, locationId: 1, available: false }]);
+
+		expect(recovered['1-93']).toBe('2026-05-26T13:26:33.000Z');
+	});
+});
+
+describe('repairLastSeen', () => {
+	it('should replace a suspect entry with its recovered timestamp', () => {
+		const repaired = repairLastSeen({
+			lastSeen: { '1-93': '2026-08-22T10:00:00.000Z', '1-22': '2026-08-22T10:00:00.000Z' },
+			suspectKeys: ['1-93'],
+			recovered: { '1-93': '2026-05-26T13:26:33.000Z' },
+		});
+
+		expect(repaired).toEqual({
+			'1-93': '2026-05-26T13:26:33.000Z',
+			'1-22': '2026-08-22T10:00:00.000Z',
+		});
+	});
+
+	it('should drop a suspect entry that could not be recovered', () => {
+		// "Never" is imprecise; "minutes ago" is false. Prefer the imprecise one.
+		const repaired = repairLastSeen({
+			lastSeen: { '3-94': '2026-08-22T10:00:00.000Z' },
+			suspectKeys: ['3-94'],
+			recovered: {},
+		});
+
+		expect(repaired).toEqual({});
+	});
+
+	it('should not mutate the stored matrix', () => {
+		const lastSeen: LastSeenMatrix = { '1-93': '2026-08-22T10:00:00.000Z' };
+		repairLastSeen({ lastSeen, suspectKeys: ['1-93'], recovered: {} });
+
+		expect(lastSeen).toEqual({ '1-93': '2026-08-22T10:00:00.000Z' });
+	});
+});

--- a/worker/src/__tests__/arm-last-seen-repair.test.ts
+++ b/worker/src/__tests__/arm-last-seen-repair.test.ts
@@ -3,7 +3,16 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { ARM_SUSPECT_SINCE, findSuspectKeys, recoverLastSeen, repairLastSeen, type RecoveryEvent } from '../arm-last-seen-repair';
+import {
+	ARM_LAST_SEEN_REPAIR_FLAG,
+	ARM_SUSPECT_SINCE,
+	findSuspectKeys,
+	recoverLastSeen,
+	repairLastSeen,
+	runArmLastSeenRepair,
+	type RecoveryEvent,
+} from '../arm-last-seen-repair';
+import { createMockDurableObjectStorage } from './fixtures/database-mocks';
 import type { AvailabilityMatrix, LastSeenMatrix, ServerTypeInfo } from '../cloud-status-service';
 
 function serverType(id: number, name: string, architecture: string): ServerTypeInfo {
@@ -122,5 +131,129 @@ describe('repairLastSeen', () => {
 		repairLastSeen({ lastSeen, suspectKeys: ['1-93'], recovered: {} });
 
 		expect(lastSeen).toEqual({ '1-93': '2026-08-22T10:00:00.000Z' });
+	});
+});
+
+describe('recoverLastSeen, cax11 in the days before the cutoff', () => {
+	// cax11 was genuinely available 2026-08-13 → 2026-08-17 09:06, then the
+	// deprecated field started asserting availability at 09:27. The real end of
+	// that window is the answer; an earlier cutoff would rewrite it back to May.
+	const events: RecoveryEvent[] = [
+		{ timestamp: '2026-05-26 13:26:33', serverTypeId: 45, locationId: 1, available: false },
+		{ timestamp: '2026-08-13 09:27:44', serverTypeId: 45, locationId: 1, available: true },
+		{ timestamp: '2026-08-17 09:06:25', serverTypeId: 45, locationId: 1, available: false },
+		{ timestamp: '2026-08-17 09:27:31', serverTypeId: 45, locationId: 1, available: true },
+	];
+
+	it('should keep the genuine availability window that ended just before it', () => {
+		expect(recoverLastSeen(events)).toEqual({ '1-45': '2026-08-17T09:06:25.000Z' });
+	});
+});
+
+describe('runArmLastSeenRepair', () => {
+	const serverTypes = SERVER_TYPES;
+	const availability: AvailabilityMatrix = { 1: [22] };
+	const corruptedLastSeen: LastSeenMatrix = {
+		'1-93': '2026-08-20T10:00:00.000Z',
+		'1-95': '2026-08-20T10:00:00.000Z',
+		'1-22': '2026-08-20T10:00:00.000Z',
+	};
+
+	function deps(initial: Record<string, unknown>, history: Record<number, RecoveryEvent[]> = {}) {
+		const storage = createMockDurableObjectStorage(initial);
+		const queried: number[] = [];
+		return {
+			storage,
+			queried,
+			deps: {
+				storage,
+				queryHistory: async (serverTypeId: number) => {
+					queried.push(serverTypeId);
+					return history[serverTypeId] ?? [];
+				},
+			},
+		};
+	}
+
+	it('should repair suspect entries and record itself as done', async () => {
+		const { storage, deps: d } = deps(
+			{ lastSeenAvailable: corruptedLastSeen, serverTypes, availability },
+			{ 93: [{ timestamp: '2026-05-26 13:26:33', serverTypeId: 93, locationId: 1, available: false }] },
+		);
+
+		const outcome = await runArmLastSeenRepair(d);
+
+		expect(outcome).toEqual({ status: 'repaired', suspect: 2, recovered: 1, cleared: 1 });
+		expect(await storage.get('lastSeenAvailable')).toEqual({
+			'1-93': '2026-05-26T13:26:33.000Z', // recovered
+			'1-22': '2026-08-20T10:00:00.000Z', // x86, untouched
+			// '1-95' cleared: nothing within retention
+		});
+		expect(await storage.get(ARM_LAST_SEEN_REPAIR_FLAG)).toBe(true);
+	});
+
+	it('should do nothing once the flag is set', async () => {
+		const { queried, deps: d } = deps({
+			[ARM_LAST_SEEN_REPAIR_FLAG]: true,
+			lastSeenAvailable: corruptedLastSeen,
+			serverTypes,
+			availability,
+		});
+
+		expect(await runArmLastSeenRepair(d)).toEqual({ status: 'already-done' });
+		expect(queried).toEqual([]);
+	});
+
+	it('should not flag itself done when nothing is selectable yet', async () => {
+		// Before the endpoint migration lands the poller still reports ARM
+		// available, so nothing is suspect. Flagging here would retire the repair
+		// without it ever running.
+		const { storage, deps: d } = deps({
+			lastSeenAvailable: corruptedLastSeen,
+			serverTypes,
+			availability: { 1: [22, 93, 95] },
+		});
+
+		expect(await runArmLastSeenRepair(d)).toEqual({ status: 'nothing-to-repair' });
+		expect(await storage.get(ARM_LAST_SEEN_REPAIR_FLAG)).toBeUndefined();
+	});
+
+	it('should wait for a snapshot rather than repairing an empty matrix', async () => {
+		const { storage, deps: d } = deps({});
+
+		expect(await runArmLastSeenRepair(d)).toEqual({ status: 'no-snapshot' });
+		expect(await storage.get(ARM_LAST_SEEN_REPAIR_FLAG)).toBeUndefined();
+	});
+
+	it('should leave the matrix and the flag untouched when a query fails', async () => {
+		const storage = createMockDurableObjectStorage({ lastSeenAvailable: corruptedLastSeen, serverTypes, availability });
+
+		await expect(
+			runArmLastSeenRepair({
+				storage,
+				queryHistory: async () => {
+					throw new Error('Analytics Engine unavailable');
+				},
+			}),
+		).rejects.toThrow('Analytics Engine unavailable');
+
+		expect(await storage.get('lastSeenAvailable')).toEqual(corruptedLastSeen);
+		expect(await storage.get(ARM_LAST_SEEN_REPAIR_FLAG)).toBeUndefined();
+	});
+
+	it('should query once per ARM type, not once per pair', async () => {
+		const { queried, deps: d } = deps({
+			lastSeenAvailable: {
+				'1-93': '2026-08-20T10:00:00.000Z',
+				'2-93': '2026-08-20T10:00:00.000Z',
+				'3-93': '2026-08-20T10:00:00.000Z',
+			},
+			serverTypes,
+			availability: { 1: [], 2: [], 3: [] },
+		});
+
+		await runArmLastSeenRepair(d);
+
+		expect(queried).toEqual([93]);
 	});
 });

--- a/worker/src/arm-last-seen-repair.ts
+++ b/worker/src/arm-last-seen-repair.ts
@@ -3,8 +3,9 @@
  *
  * Until #288 the poller read availability from `datacenter.server_types.
  * available`, which Hetzner deprecated on 2026-04-01 along with the guarantee
- * that it stays accurate. It drifted, and from 2026-08-13 it reported the CAX
- * (ARM) types as available in fsn1/nbg1/hel1 while they could not be created.
+ * that it stays accurate. It drifted, and from 2026-08-17 09:27:31 it reported
+ * all four CAX (ARM) types as available in fsn1/nbg1/hel1 while they could not
+ * be created (see `ARM_SUSPECT_SINCE` for how that instant is established).
  * Every poll in that window stamped `lastSeenAvailable` with "now", overwriting
  * the true timestamps — for most pairs, a date in May 2026.
  *
@@ -23,8 +24,13 @@
  * It repairs a fixed, historical corruption. The instant the storage flag
  * `armLastSeenRepairV1` is set on the live Durable Object, every subsequent
  * call is a no-op, and this file plus `CloudAvailabilityDO.repairArmLastSeen`
- * and its `ensureInitialized` call site can be deleted outright. Confirm via
- * the worker's `/debug` route, which lists the storage keys.
+ * and its call in `alarm()` can be deleted outright.
+ *
+ * Confirm from the worker log — `wrangler tail` — which reports either
+ * "Repaired N ARM last-seen entries" on the run that does the work, or
+ * "ARM last-seen repair: already-done" on every alarm after it. (The `/debug`
+ * route also lists the storage keys, but the worker sets `workers_dev: false`
+ * with no routes, so it is not reachable in production.)
  *
  * Nothing enforces that, so it is stated here rather than left to be inferred.
  */

--- a/worker/src/arm-last-seen-repair.ts
+++ b/worker/src/arm-last-seen-repair.ts
@@ -222,8 +222,8 @@ export type RepairOutcome =
  * Run the one-off repair, at most once.
  *
  * Throws on a query or storage failure, leaving the flag unset and the stored
- * matrix untouched, so the next boot retries. A wrong timestamp is recoverable;
- * a half-written matrix is not.
+ * matrix untouched, so the next alarm retries. A wrong timestamp is
+ * recoverable; a half-written matrix is not.
  */
 export async function runArmLastSeenRepair({ storage, queryHistory }: RepairDeps): Promise<RepairOutcome> {
 	if (await storage.get<boolean>(ARM_LAST_SEEN_REPAIR_FLAG)) return { status: 'already-done' };

--- a/worker/src/arm-last-seen-repair.ts
+++ b/worker/src/arm-last-seen-repair.ts
@@ -13,9 +13,20 @@
  * have not been available in months. This module rewrites those entries from
  * Analytics Engine, which still holds the genuine transitions.
  *
- * It is deliberately narrow and self-deleting: it touches only ARM pairs, only
- * entries stamped inside the suspect window, and runs once. Delete this module
- * (and its call site) once it has run in production.
+ * It is deliberately narrow: it touches only ARM pairs, only entries stamped
+ * inside the suspect window, and runs once.
+ *
+ * ---
+ *
+ * THIS MODULE IS DEAD CODE ONCE IT HAS RUN IN PRODUCTION.
+ *
+ * It repairs a fixed, historical corruption. The instant the storage flag
+ * `armLastSeenRepairV1` is set on the live Durable Object, every subsequent
+ * call is a no-op, and this file plus `CloudAvailabilityDO.repairArmLastSeen`
+ * and its `ensureInitialized` call site can be deleted outright. Confirm via
+ * the worker's `/debug` route, which lists the storage keys.
+ *
+ * Nothing enforces that, so it is stated here rather than left to be inferred.
  */
 
 import type { AvailabilityMatrix, LastSeenMatrix, ServerTypeInfo } from './cloud-status-service';
@@ -26,12 +37,24 @@ export const ARM_LAST_SEEN_REPAIR_FLAG = 'armLastSeenRepairV1';
 /**
  * When the deprecated field started claiming ARM availability.
  *
- * Inferred, not documented: it is the earliest ARM `available` transition in
- * the suspect run (cax11 in fsn1/nbg1, 2026-08-13). Nothing before it is
- * touched, so an over-wide guess costs accuracy only for genuinely stale
- * entries, never for correct ones.
+ * Hetzner does not document this, but the transition record pins it. All twelve
+ * ARM pairs flipped available at 2026-08-17 09:27:31, and twenty-one minutes
+ * earlier, at 09:06:25, the same field reported cax11 in fsn1 and nbg1
+ * *unavailable*. It could not have been asserting ARM availability before a
+ * moment when it was still denying it, so the fiction begins at 09:27:31.
+ *
+ * That also means the cax11 availability of 2026-08-13 → 2026-08-17 09:06 is
+ * genuine and must be preserved: it arrived in two locations an hour apart,
+ * which is stock moving, not a data source changing. An earlier cutoff would
+ * rewrite those two pairs from 2026-08-17 back to May and lose a real window.
+ *
+ * Do not widen this to catch more: the window is five days, and many x86 types
+ * legitimately flap inside it. The ARM restriction in `findSuspectKeys` is what
+ * keeps those from being "repaired" to an earlier date — verified 2026-08-22,
+ * twice, when the deprecated and current endpoints disagreed on exactly the
+ * twelve ARM pairs out of 114 compared.
  */
-export const ARM_SUSPECT_SINCE = '2026-08-13T00:00:00.000Z';
+export const ARM_SUSPECT_SINCE = '2026-08-17T09:27:00.000Z';
 
 export interface RepairInput {
 	/** The stored matrix, keyed `"locationId-serverTypeId"`. */
@@ -49,10 +72,14 @@ export interface RepairInput {
 /**
  * Replace each suspect entry with its recovered timestamp, or drop it.
  *
- * Dropping is deliberate. The UI renders a missing entry as "Never", which is
- * imprecise but honest about not knowing; leaving the bogus value in place
- * asserts the pair was available minutes ago, which is simply false and is the
- * thing being complained about.
+ * Dropping is a choice between two wrong answers, not a retreat to a right one.
+ * A missing entry renders as a grey "Never" — identical to ash and hil, where
+ * ARM has genuinely never been offered — so fsn1/nbg1/hel1 will claim ARM was
+ * never available there, when it was, in May. That is still preferable to
+ * asserting it was available minutes ago, which is both false and the specific
+ * complaint in #287, but it is not a neutral outcome and should not be
+ * described as one. Representing "unknown" as its own state would be better,
+ * and needs a UI decision this repair should not make.
  */
 export function repairLastSeen({ lastSeen, suspectKeys, recovered }: RepairInput): LastSeenMatrix {
 	const repaired = { ...lastSeen };
@@ -150,4 +177,72 @@ function parseEventTimestamp(timestamp: string): number {
 	if (!normalized.includes('T')) normalized = normalized.replace(' ', 'T');
 	if (!normalized.endsWith('Z') && !/[+-]\d{2}:\d{2}$/.test(normalized)) normalized += 'Z';
 	return Date.parse(normalized);
+}
+
+/**
+ * The subset of `DurableObjectStorage` the repair needs, so it can be driven by
+ * a test double rather than a live Durable Object.
+ */
+export interface RepairStorage {
+	get<T>(key: string): Promise<T | undefined>;
+	put(key: string, value: unknown): Promise<void>;
+}
+
+export interface RepairDeps {
+	storage: RepairStorage;
+	/** Transitions for one server type across every location, within retention. */
+	queryHistory(serverTypeId: number): Promise<RecoveryEvent[]>;
+}
+
+export type RepairOutcome =
+	/** The flag is set; the repair has already run. */
+	| { status: 'already-done' }
+	/** Nothing has been polled yet, so there is no matrix to repair. */
+	| { status: 'no-snapshot' }
+	/**
+	 * No identifiable suspect entries. Deliberately does *not* set the flag:
+	 * before the endpoint migration lands, the poller still reports the affected
+	 * pairs as available and nothing is selectable, so recording "done" here
+	 * would retire the repair without it ever running.
+	 */
+	| { status: 'nothing-to-repair' }
+	| { status: 'repaired'; suspect: number; recovered: number; cleared: number };
+
+/**
+ * Run the one-off repair, at most once.
+ *
+ * Throws on a query or storage failure, leaving the flag unset and the stored
+ * matrix untouched, so the next boot retries. A wrong timestamp is recoverable;
+ * a half-written matrix is not.
+ */
+export async function runArmLastSeenRepair({ storage, queryHistory }: RepairDeps): Promise<RepairOutcome> {
+	if (await storage.get<boolean>(ARM_LAST_SEEN_REPAIR_FLAG)) return { status: 'already-done' };
+
+	const [lastSeen, serverTypes, availability] = await Promise.all([
+		storage.get<LastSeenMatrix>('lastSeenAvailable'),
+		storage.get<ServerTypeInfo[]>('serverTypes'),
+		storage.get<AvailabilityMatrix>('availability'),
+	]);
+
+	if (!lastSeen || !serverTypes || !availability) return { status: 'no-snapshot' };
+
+	const suspectKeys = findSuspectKeys(lastSeen, serverTypes, availability);
+	if (suspectKeys.length === 0) return { status: 'nothing-to-repair' };
+
+	// One query per ARM type covers every location it is offered in — four round
+	// trips rather than one per pair. Issued together; they are independent.
+	const armTypeIds = [...new Set(suspectKeys.map((key) => Number(key.slice(key.indexOf('-') + 1))))];
+	const histories = await Promise.all(armTypeIds.map((id) => queryHistory(id)));
+
+	const recovered = recoverLastSeen(histories.flat());
+	await storage.put('lastSeenAvailable', repairLastSeen({ lastSeen, suspectKeys, recovered }));
+	await storage.put(ARM_LAST_SEEN_REPAIR_FLAG, true);
+
+	const recoveredCount = suspectKeys.filter((key) => recovered[key]).length;
+	return {
+		status: 'repaired',
+		suspect: suspectKeys.length,
+		recovered: recoveredCount,
+		cleared: suspectKeys.length - recoveredCount,
+	};
 }

--- a/worker/src/arm-last-seen-repair.ts
+++ b/worker/src/arm-last-seen-repair.ts
@@ -1,0 +1,153 @@
+/**
+ * One-off repair of `lastSeenAvailable` after the deprecated availability field.
+ *
+ * Until #288 the poller read availability from `datacenter.server_types.
+ * available`, which Hetzner deprecated on 2026-04-01 along with the guarantee
+ * that it stays accurate. It drifted, and from 2026-08-13 it reported the CAX
+ * (ARM) types as available in fsn1/nbg1/hel1 while they could not be created.
+ * Every poll in that window stamped `lastSeenAvailable` with "now", overwriting
+ * the true timestamps — for most pairs, a date in May 2026.
+ *
+ * Fixing the source does not undo that: the stored matrix keeps the bogus
+ * timestamps, so the status table reads "last seen: minutes ago" for pairs that
+ * have not been available in months. This module rewrites those entries from
+ * Analytics Engine, which still holds the genuine transitions.
+ *
+ * It is deliberately narrow and self-deleting: it touches only ARM pairs, only
+ * entries stamped inside the suspect window, and runs once. Delete this module
+ * (and its call site) once it has run in production.
+ */
+
+import type { AvailabilityMatrix, LastSeenMatrix, ServerTypeInfo } from './cloud-status-service';
+
+/** Storage key recording that the repair has already run. */
+export const ARM_LAST_SEEN_REPAIR_FLAG = 'armLastSeenRepairV1';
+
+/**
+ * When the deprecated field started claiming ARM availability.
+ *
+ * Inferred, not documented: it is the earliest ARM `available` transition in
+ * the suspect run (cax11 in fsn1/nbg1, 2026-08-13). Nothing before it is
+ * touched, so an over-wide guess costs accuracy only for genuinely stale
+ * entries, never for correct ones.
+ */
+export const ARM_SUSPECT_SINCE = '2026-08-13T00:00:00.000Z';
+
+export interface RepairInput {
+	/** The stored matrix, keyed `"locationId-serverTypeId"`. */
+	lastSeen: LastSeenMatrix;
+	/** Keys whose stored timestamp came from the deprecated field. */
+	suspectKeys: string[];
+	/**
+	 * Last genuine availability per suspect key, recovered from Analytics
+	 * Engine. A key missing here has no answer inside AE's three-month
+	 * retention.
+	 */
+	recovered: Record<string, string>;
+}
+
+/**
+ * Replace each suspect entry with its recovered timestamp, or drop it.
+ *
+ * Dropping is deliberate. The UI renders a missing entry as "Never", which is
+ * imprecise but honest about not knowing; leaving the bogus value in place
+ * asserts the pair was available minutes ago, which is simply false and is the
+ * thing being complained about.
+ */
+export function repairLastSeen({ lastSeen, suspectKeys, recovered }: RepairInput): LastSeenMatrix {
+	const repaired = { ...lastSeen };
+
+	for (const key of suspectKeys) {
+		const trueLastSeen = recovered[key];
+		if (trueLastSeen) {
+			repaired[key] = trueLastSeen;
+		} else {
+			delete repaired[key];
+		}
+	}
+
+	return repaired;
+}
+
+/**
+ * Entries that the deprecated field is responsible for: an ARM pair, stamped
+ * inside the suspect window, that the authoritative endpoint now reports as
+ * unavailable.
+ *
+ * The last condition matters — a pair that really is available right now has a
+ * correct timestamp whatever wrote it, and must be left alone.
+ */
+export function findSuspectKeys(
+	lastSeen: LastSeenMatrix,
+	serverTypes: ServerTypeInfo[],
+	availability: AvailabilityMatrix,
+	suspectSince: string = ARM_SUSPECT_SINCE,
+): string[] {
+	const armIds = new Set(serverTypes.filter((st) => st.architecture === 'arm').map((st) => st.id));
+	const threshold = Date.parse(suspectSince);
+	const suspect: string[] = [];
+
+	for (const [key, timestamp] of Object.entries(lastSeen)) {
+		const separator = key.indexOf('-');
+		const locationId = Number(key.slice(0, separator));
+		const serverTypeId = Number(key.slice(separator + 1));
+
+		if (!armIds.has(serverTypeId)) continue;
+		if (!(Date.parse(timestamp) >= threshold)) continue;
+		if ((availability[locationId] ?? []).includes(serverTypeId)) continue;
+
+		suspect.push(key);
+	}
+
+	return suspect;
+}
+
+/** A transition as returned by the history query. */
+export interface RecoveryEvent {
+	timestamp: string;
+	serverTypeId: number;
+	locationId: number;
+	available: boolean;
+	seed?: boolean;
+}
+
+/**
+ * The last moment each pair was genuinely available, read off the transitions
+ * that predate the suspect window.
+ *
+ * A pair drops out of availability at its `unavailable` transition, so that
+ * timestamp is when it was last seen — accurate to one poll interval. Events at
+ * or after `suspectSince` are ignored: they are the bogus run itself, plus the
+ * single corrective `unavailable` the poller writes once #288 deploys.
+ */
+export function recoverLastSeen(events: RecoveryEvent[], suspectSince: string = ARM_SUSPECT_SINCE): Record<string, string> {
+	const threshold = Date.parse(suspectSince);
+	const recovered: Record<string, string> = {};
+
+	for (const event of events) {
+		if (event.seed) continue;
+		if (event.available) continue;
+
+		const at = parseEventTimestamp(event.timestamp);
+		if (at >= threshold) continue;
+
+		const key = `${event.locationId}-${event.serverTypeId}`;
+		const known = recovered[key];
+		if (!known || parseEventTimestamp(known) < at) {
+			recovered[key] = new Date(at).toISOString();
+		}
+	}
+
+	return recovered;
+}
+
+/**
+ * Analytics Engine returns `"YYYY-MM-DD HH:MM:SS"` — UTC, but without a zone
+ * designator, which `Date.parse` would otherwise read as local time.
+ */
+function parseEventTimestamp(timestamp: string): number {
+	let normalized = timestamp;
+	if (!normalized.includes('T')) normalized = normalized.replace(' ', 'T');
+	if (!normalized.endsWith('Z') && !/[+-]\d{2}:\d{2}$/.test(normalized)) normalized += 'Z';
+	return Date.parse(normalized);
+}

--- a/worker/src/arm-last-seen-repair.ts
+++ b/worker/src/arm-last-seen-repair.ts
@@ -80,6 +80,10 @@ export interface RepairInput {
  * complaint in #287, but it is not a neutral outcome and should not be
  * described as one. Representing "unknown" as its own state would be better,
  * and needs a UI decision this repair should not make.
+ *
+ * Either way the cell self-corrects the moment the pair is next in stock:
+ * `updateLastSeenTimestamps` stamps every available pair on every poll. This
+ * repair is worth the remaining duration of the outage, no more.
  */
 export function repairLastSeen({ lastSeen, suspectKeys, recovered }: RepairInput): LastSeenMatrix {
 	const repaired = { ...lastSeen };

--- a/worker/src/cloud-availability-do.ts
+++ b/worker/src/cloud-availability-do.ts
@@ -44,7 +44,6 @@ const RECOVERY_LOOKBACK_MS = 92 * 24 * 60 * 60 * 1000;
 export class CloudAvailabilityDO extends DurableObject<CloudAvailabilityEnv> {
 	private fetchIntervalMs: number;
 	private initializing: boolean = false;
-	private repairing: boolean = false;
 
 	// Services
 	private cloudStatusService: CloudStatusService;
@@ -105,12 +104,6 @@ export class CloudAvailabilityDO extends DurableObject<CloudAvailabilityEnv> {
 			const lastUpdated = await this.ctx.storage.get<string>('lastUpdated');
 			console.log(`[CloudAvailabilityDO ${this.ctx.id}] Last cloud status updated: ${lastUpdated || 'never'}`);
 
-			// Correct the timestamps the deprecated availability field left behind.
-			// Runs at most once, and never blocks the poll.
-			this.ctx.waitUntil(
-				this.repairArmLastSeen().catch((err) => console.error(`[CloudAvailabilityDO ${this.ctx.id}] ARM last-seen repair failed:`, err)),
-			);
-
 			// Trigger initial fetch if needed
 			if (!lastUpdated) {
 				this.fetchCloudStatus().catch((err) =>
@@ -140,6 +133,13 @@ export class CloudAvailabilityDO extends DurableObject<CloudAvailabilityEnv> {
 
 		try {
 			await this.fetchCloudStatus(metrics);
+
+			// Correct the timestamps the deprecated availability field left behind.
+			// Runs at most once, after the poll has refreshed the snapshot it reads.
+			// Deliberately on the alarm rather than `ensureInitialized`: a state
+			// migration should not be triggered by whoever happens to load the page
+			// first. The alarm fires within a minute of deploy, in the background.
+			await this.repairArmLastSeen();
 		} catch (error) {
 			failed = true;
 			console.error(`[CloudAvailabilityDO ${this.ctx.id}] Failed to update cloud status:`, error);
@@ -245,17 +245,11 @@ export class CloudAvailabilityDO extends DurableObject<CloudAvailabilityEnv> {
 	 * deprecated availability field — see `arm-last-seen-repair.ts`, which holds
 	 * the logic and the note on when this becomes dead code.
 	 *
-	 * Reached from `ensureInitialized`, so the trigger is whichever comes first
-	 * after a deploy: the poll alarm, or the first `getStatus()` RPC — that is, a
-	 * user opening /cloud-status. It runs under `waitUntil` either way, so it
-	 * never blocks that response.
+	 * Driven by the alarm, immediately after the poll that refreshes the snapshot
+	 * it reads. Never from a request path: this rewrites stored state, and which
+	 * user loads the page first should not decide when that happens.
 	 */
 	private async repairArmLastSeen(): Promise<void> {
-		// Mirrors `initializing`: two concurrent page loads can both clear the
-		// storage flag before either sets it, which would duplicate the queries.
-		if (this.repairing) return;
-		this.repairing = true;
-
 		try {
 			if (!this.env.CF_ACCOUNT_ID || !this.env.CF_BEARER_TOKEN) {
 				console.warn(`[CloudAvailabilityDO ${this.ctx.id}] ARM last-seen repair needs Analytics Engine credentials; deferring.`);
@@ -281,8 +275,10 @@ export class CloudAvailabilityDO extends DurableObject<CloudAvailabilityEnv> {
 			} else {
 				console.log(`[CloudAvailabilityDO ${this.ctx.id}] ARM last-seen repair: ${outcome.status}.`);
 			}
-		} finally {
-			this.repairing = false;
+		} catch (error) {
+			// Never let a repair failure fail the poll: the flag stays unset and the
+			// stored matrix untouched, so the next alarm retries.
+			console.error(`[CloudAvailabilityDO ${this.ctx.id}] ARM last-seen repair failed:`, error);
 		}
 	}
 

--- a/worker/src/cloud-availability-do.ts
+++ b/worker/src/cloud-availability-do.ts
@@ -27,7 +27,16 @@ interface CloudAvailabilityEnv {
 
 const DEFAULT_FETCH_INTERVAL_MS = 60 * 1000; // 1 minute
 
-/** Analytics Engine's retention, the widest window the repair can recover from. */
+/**
+ * Analytics Engine's retention, and the widest window the repair can recover
+ * from. Asking for more is not merely unhelpful, it is measurably pointless:
+ * probed on 2026-08-22, queries for 120, 180, 365, and 730 days all returned
+ * the same 3,424 rows as a 92-day query, with nothing older than 92.5 days —
+ * well short of the 10,000-row cap, so a real boundary rather than truncation.
+ *
+ * A pair whose last transition predates that is unrecoverable, permanently. Its
+ * entry is cleared rather than left holding a false timestamp.
+ */
 const RECOVERY_LOOKBACK_MS = 92 * 24 * 60 * 60 * 1000;
 
 // See the note in `auction-import-do.ts`: parameterizing Env lets the base class

--- a/worker/src/cloud-availability-do.ts
+++ b/worker/src/cloud-availability-do.ts
@@ -11,6 +11,8 @@ import { NotificationService } from './notification-service';
 import { CloudAlertService } from './cloud-alert-service';
 import { CloudNotificationService } from './cloud-notifications/cloud-notification-service';
 import { AnalyticsQueryService } from './analytics-query-service';
+import { ARM_LAST_SEEN_REPAIR_FLAG, findSuspectKeys, recoverLastSeen, repairLastSeen, type RecoveryEvent } from './arm-last-seen-repair';
+import type { AvailabilityMatrix, LastSeenMatrix, ServerTypeInfo } from './cloud-status-service';
 
 interface CloudAvailabilityEnv {
 	HETZNER_API_TOKEN: string;
@@ -25,6 +27,9 @@ interface CloudAvailabilityEnv {
 }
 
 const DEFAULT_FETCH_INTERVAL_MS = 60 * 1000; // 1 minute
+
+/** Analytics Engine's retention, the widest window the repair can recover from. */
+const RECOVERY_LOOKBACK_MS = 92 * 24 * 60 * 60 * 1000;
 
 // See the note in `auction-import-do.ts`: parameterizing Env lets the base class
 // declare `ctx`/`env` at the right types rather than being shadowed.
@@ -90,6 +95,12 @@ export class CloudAvailabilityDO extends DurableObject<CloudAvailabilityEnv> {
 
 			const lastUpdated = await this.ctx.storage.get<string>('lastUpdated');
 			console.log(`[CloudAvailabilityDO ${this.ctx.id}] Last cloud status updated: ${lastUpdated || 'never'}`);
+
+			// Correct the timestamps the deprecated availability field left behind.
+			// Runs at most once, and never blocks the poll.
+			this.ctx.waitUntil(
+				this.repairArmLastSeen().catch((err) => console.error(`[CloudAvailabilityDO ${this.ctx.id}] ARM last-seen repair failed:`, err)),
+			);
 
 			// Trigger initial fetch if needed
 			if (!lastUpdated) {
@@ -218,6 +229,65 @@ export class CloudAvailabilityDO extends DurableObject<CloudAvailabilityEnv> {
 			console.error(`[CloudAvailabilityDO ${this.ctx.id}] Error in getHistoricalAvailability RPC:`, error);
 			throw error;
 		}
+	}
+
+	/**
+	 * One-off repair of the `lastSeenAvailable` entries written from Hetzner's
+	 * deprecated availability field — see `arm-last-seen-repair.ts`. Remove this
+	 * method and its call once it has run in production.
+	 *
+	 * Any failure leaves the flag unset so the next boot retries, and leaves the
+	 * stored matrix untouched: a wrong timestamp is better than a lost one.
+	 */
+	private async repairArmLastSeen(): Promise<void> {
+		if (await this.ctx.storage.get<boolean>(ARM_LAST_SEEN_REPAIR_FLAG)) return;
+
+		if (!this.env.CF_ACCOUNT_ID || !this.env.CF_BEARER_TOKEN) {
+			console.warn(`[CloudAvailabilityDO ${this.ctx.id}] ARM last-seen repair needs Analytics Engine credentials; deferring.`);
+			return;
+		}
+
+		const [lastSeen, serverTypes, availability] = await Promise.all([
+			this.ctx.storage.get<LastSeenMatrix>('lastSeenAvailable'),
+			this.ctx.storage.get<ServerTypeInfo[]>('serverTypes'),
+			this.ctx.storage.get<AvailabilityMatrix>('availability'),
+		]);
+
+		// Nothing polled yet — there is no matrix to repair, and the first poll
+		// will write correct values anyway.
+		if (!lastSeen || !serverTypes || !availability) return;
+
+		const suspectKeys = findSuspectKeys(lastSeen, serverTypes, availability);
+
+		// Deliberately no flag here. Suspect entries are only identifiable once the
+		// poller reads the authoritative endpoint (#288) and starts reporting the
+		// affected pairs as unavailable; before that this finds nothing, and
+		// recording "done" would retire the repair without it ever running.
+		// Re-checking is three storage reads and no Analytics Engine traffic.
+		if (suspectKeys.length === 0) return;
+
+		// One query per ARM type covers every location it is offered in, which is
+		// four round trips rather than one per pair.
+		const armTypeIds = [...new Set(suspectKeys.map((key) => Number(key.slice(key.indexOf('-') + 1))))];
+		const endDate = new Date().toISOString();
+		const startDate = new Date(Date.now() - RECOVERY_LOOKBACK_MS).toISOString();
+
+		const events: RecoveryEvent[] = [];
+		for (const serverTypeId of armTypeIds) {
+			const history = await this.getHistoricalAvailability({ startDate, endDate, serverTypeId });
+			events.push(...(history.data as RecoveryEvent[]));
+		}
+
+		const recovered = recoverLastSeen(events);
+		const repaired = repairLastSeen({ lastSeen, suspectKeys, recovered });
+
+		await this.ctx.storage.put('lastSeenAvailable', repaired);
+		await this.ctx.storage.put(ARM_LAST_SEEN_REPAIR_FLAG, true);
+
+		console.log(
+			`[CloudAvailabilityDO ${this.ctx.id}] Repaired ${suspectKeys.length} ARM last-seen entries ` +
+				`(${Object.keys(recovered).length} recovered from Analytics Engine, ${suspectKeys.length - Object.keys(recovered).length} cleared as unknown).`,
+		);
 	}
 
 	private async fetchCloudStatus(metrics?: ReturnType<typeof createMetrics>): Promise<void> {

--- a/worker/src/cloud-availability-do.ts
+++ b/worker/src/cloud-availability-do.ts
@@ -11,8 +11,7 @@ import { NotificationService } from './notification-service';
 import { CloudAlertService } from './cloud-alert-service';
 import { CloudNotificationService } from './cloud-notifications/cloud-notification-service';
 import { AnalyticsQueryService } from './analytics-query-service';
-import { ARM_LAST_SEEN_REPAIR_FLAG, findSuspectKeys, recoverLastSeen, repairLastSeen, type RecoveryEvent } from './arm-last-seen-repair';
-import type { AvailabilityMatrix, LastSeenMatrix, ServerTypeInfo } from './cloud-status-service';
+import { runArmLastSeenRepair, type RecoveryEvent } from './arm-last-seen-repair';
 
 interface CloudAvailabilityEnv {
 	HETZNER_API_TOKEN: string;
@@ -36,6 +35,7 @@ const RECOVERY_LOOKBACK_MS = 92 * 24 * 60 * 60 * 1000;
 export class CloudAvailabilityDO extends DurableObject<CloudAvailabilityEnv> {
 	private fetchIntervalMs: number;
 	private initializing: boolean = false;
+	private repairing: boolean = false;
 
 	// Services
 	private cloudStatusService: CloudStatusService;
@@ -233,61 +233,48 @@ export class CloudAvailabilityDO extends DurableObject<CloudAvailabilityEnv> {
 
 	/**
 	 * One-off repair of the `lastSeenAvailable` entries written from Hetzner's
-	 * deprecated availability field — see `arm-last-seen-repair.ts`. Remove this
-	 * method and its call once it has run in production.
+	 * deprecated availability field — see `arm-last-seen-repair.ts`, which holds
+	 * the logic and the note on when this becomes dead code.
 	 *
-	 * Any failure leaves the flag unset so the next boot retries, and leaves the
-	 * stored matrix untouched: a wrong timestamp is better than a lost one.
+	 * Reached from `ensureInitialized`, so the trigger is whichever comes first
+	 * after a deploy: the poll alarm, or the first `getStatus()` RPC — that is, a
+	 * user opening /cloud-status. It runs under `waitUntil` either way, so it
+	 * never blocks that response.
 	 */
 	private async repairArmLastSeen(): Promise<void> {
-		if (await this.ctx.storage.get<boolean>(ARM_LAST_SEEN_REPAIR_FLAG)) return;
+		// Mirrors `initializing`: two concurrent page loads can both clear the
+		// storage flag before either sets it, which would duplicate the queries.
+		if (this.repairing) return;
+		this.repairing = true;
 
-		if (!this.env.CF_ACCOUNT_ID || !this.env.CF_BEARER_TOKEN) {
-			console.warn(`[CloudAvailabilityDO ${this.ctx.id}] ARM last-seen repair needs Analytics Engine credentials; deferring.`);
-			return;
+		try {
+			if (!this.env.CF_ACCOUNT_ID || !this.env.CF_BEARER_TOKEN) {
+				console.warn(`[CloudAvailabilityDO ${this.ctx.id}] ARM last-seen repair needs Analytics Engine credentials; deferring.`);
+				return;
+			}
+
+			const endDate = new Date().toISOString();
+			const startDate = new Date(Date.now() - RECOVERY_LOOKBACK_MS).toISOString();
+
+			const outcome = await runArmLastSeenRepair({
+				storage: this.ctx.storage,
+				queryHistory: async (serverTypeId) => {
+					const history = await this.getHistoricalAvailability({ startDate, endDate, serverTypeId });
+					return history.data as RecoveryEvent[];
+				},
+			});
+
+			if (outcome.status === 'repaired') {
+				console.log(
+					`[CloudAvailabilityDO ${this.ctx.id}] Repaired ${outcome.suspect} ARM last-seen entries ` +
+						`(${outcome.recovered} recovered from Analytics Engine, ${outcome.cleared} cleared as unknown).`,
+				);
+			} else {
+				console.log(`[CloudAvailabilityDO ${this.ctx.id}] ARM last-seen repair: ${outcome.status}.`);
+			}
+		} finally {
+			this.repairing = false;
 		}
-
-		const [lastSeen, serverTypes, availability] = await Promise.all([
-			this.ctx.storage.get<LastSeenMatrix>('lastSeenAvailable'),
-			this.ctx.storage.get<ServerTypeInfo[]>('serverTypes'),
-			this.ctx.storage.get<AvailabilityMatrix>('availability'),
-		]);
-
-		// Nothing polled yet — there is no matrix to repair, and the first poll
-		// will write correct values anyway.
-		if (!lastSeen || !serverTypes || !availability) return;
-
-		const suspectKeys = findSuspectKeys(lastSeen, serverTypes, availability);
-
-		// Deliberately no flag here. Suspect entries are only identifiable once the
-		// poller reads the authoritative endpoint (#288) and starts reporting the
-		// affected pairs as unavailable; before that this finds nothing, and
-		// recording "done" would retire the repair without it ever running.
-		// Re-checking is three storage reads and no Analytics Engine traffic.
-		if (suspectKeys.length === 0) return;
-
-		// One query per ARM type covers every location it is offered in, which is
-		// four round trips rather than one per pair.
-		const armTypeIds = [...new Set(suspectKeys.map((key) => Number(key.slice(key.indexOf('-') + 1))))];
-		const endDate = new Date().toISOString();
-		const startDate = new Date(Date.now() - RECOVERY_LOOKBACK_MS).toISOString();
-
-		const events: RecoveryEvent[] = [];
-		for (const serverTypeId of armTypeIds) {
-			const history = await this.getHistoricalAvailability({ startDate, endDate, serverTypeId });
-			events.push(...(history.data as RecoveryEvent[]));
-		}
-
-		const recovered = recoverLastSeen(events);
-		const repaired = repairLastSeen({ lastSeen, suspectKeys, recovered });
-
-		await this.ctx.storage.put('lastSeenAvailable', repaired);
-		await this.ctx.storage.put(ARM_LAST_SEEN_REPAIR_FLAG, true);
-
-		console.log(
-			`[CloudAvailabilityDO ${this.ctx.id}] Repaired ${suspectKeys.length} ARM last-seen entries ` +
-				`(${Object.keys(recovered).length} recovered from Analytics Engine, ${suspectKeys.length - Object.keys(recovered).length} cleared as unknown).`,
-		);
 	}
 
 	private async fetchCloudStatus(metrics?: ReturnType<typeof createMetrics>): Promise<void> {


### PR DESCRIPTION
The optional third piece of #287, and **ARM-only**: it rewrites the "last seen available" timestamps for the twelve CAX pairs (cax11/21/31/41 × fsn1/nbg1/hel1) that Hetzner's deprecated availability field corrupted. No other server type is affected — verified by comparing the deprecated and current endpoints across all 114 (type × location) pairs, which disagree on exactly those twelve and nothing else.

Drop it if you'd rather let the bad timestamps sit — nothing else depends on it. Without it, every ARM cell reads "last seen: a few minutes ago" for as long as unavailability lasts, which by our own transition record is now three months.

## The problem

While the poller read Hetzner's deprecated availability field (#288), it stamped `lastSeenAvailable` with "now" for every ARM pair on every 60-second poll. That overwrote the real timestamps, which for most pairs were dated May 2026.

Fixing the source does not undo that. The stored matrix keeps the bogus values, so once #288 lands the status table freezes at "last seen: minutes ago" for pairs that have not actually been available in three months — the specific complaint in the issue.

Analytics Engine still holds the genuine transitions. For `cax21`/`fsn1`:

```
2026-05-26 12:58:20  UP
2026-05-26 13:26:33  DOWN   ← the real "last seen available"
2026-08-17 09:27:31  UP     ← the deprecated field's fiction
```

## What it actually changes: twelve strings

Worth being concrete up front, because the scope is narrower than the discussion below suggests.

`lastSeenAvailable` holds **one timestamp per (location × server type)** — the last moment we observed it in stock. The status table renders that as the relative-time line under each cell's icon, colour-banded (green under 24h, amber under 7d, red older, grey when absent). This PR rewrites twelve of those strings. Nothing else.

It does **not** touch the availability heatmap, which is drawn from the Analytics Engine transition stream and is #289's territory. There are no intermediate dates involved; there is only ever one timestamp per cell.

Projected against live data, this is the complete effect:

| pair | after #288, without this PR | with this PR |
| --- | --- | --- |
| cax11 · fsn1, nbg1 | "2 minutes ago" | **"5 days ago"** — genuinely available until 2026-08-17 09:06 |
| cax21 · fsn1, nbg1 | "2 minutes ago" | **"3 months ago"** — 2026-05-26 and 2026-05-23 |
| cax31 · fsn1 | "2 minutes ago" | **"3 months ago"** — 2026-05-22 |
| cax41 · fsn1 | "2 minutes ago" | **"3 months ago"** — 2026-05-22 |
| the remaining six | "2 minutes ago" | **"Never"** — no record survives, see below |

For the avoidance of doubt: **ARM is not currently available.** It has been out of stock since May. Production still shows it green only because it is still running the deprecated field; that is what #288 fixes. Without this PR the timestamps simply freeze at the moment #288 deploys, so every ARM cell would read "last seen: a few minutes ago" — the most misleading possible value, since it implies you just missed one.

**This corrects itself when ARM restocks.** `updateLastSeenTimestamps` stamps every currently-available pair on each poll, so the first poll that sees ARM in stock overwrites the bogus entry with a genuine one, and every cleared "Never" fills back in. So the repair is worth exactly as much as the remaining duration of the outage — which is unknown, but has already run from 2026-05-22 to today. If you expect ARM back shortly, the honest answer is to close this and let it fix itself.

## How it works

A one-off repair, run at most once, from the poll alarm — immediately after the poll that refreshes the snapshot it reads:

- **Select** only ARM pairs stamped inside the suspect window that the authoritative endpoint now reports as unavailable. A pair that genuinely is available right now has a correct timestamp whoever wrote it, and is left alone.
- **Recover** each one from the last `unavailable` transition predating the suspect window. That is the moment the pair dropped out of stock, accurate to one poll interval. Events at or after the window are skipped: they are the bogus run itself, plus the single corrective `unavailable` the poller writes once #288 deploys.
- **Clear** an entry with no answer inside retention, rather than leaving the false one.

Four Analytics Engine queries total, one per ARM type, issued concurrently.

## The six that read "Never", and why there is no better answer

Six pairs last changed state before Analytics Engine's retention window, so no record of their availability survives anywhere. `cax41` in Helsinki *was* available once; we can no longer say when.

A cleared entry renders as a grey "Never" — visually identical to Ashburn and Hillsboro, where ARM has genuinely never been offered. That is a false statement, and swapping one false statement for another deserves saying out loud. The argument for it is that "available 2 minutes ago" is false *and* actively misleading, while "never available here" is false but does not send anyone refreshing the page hoping to catch one.

**A longer lookback does not help — measured, not assumed.** Probed against production on 2026-08-22:

```
window   92d →  3405 rows | oldest 2026-05-22 (92.0d ago)
window  120d →  3424 rows | oldest 2026-05-22 (92.5d ago)
window  180d →  3424 rows | oldest 2026-05-22 (92.5d ago)
window  365d →  3424 rows | oldest 2026-05-22 (92.5d ago)
window  730d →  3424 rows | oldest 2026-05-22 (92.5d ago)
```

A two-year request returns nothing older than 92.5 days, and at 3,424 rows the 10,000-row query cap is not in play — so that is a real retention boundary, not truncation. Those six cells will stay grey until ARM is actually back in stock.

The alternative would be a distinct "not seen in the last three months" state, which means a new visual state and a legend decision. That is a UI change and does not belong in a data repair; a deliberate choice was made here not to invent one.

## Why the cutoff is 2026-08-17 09:27:31

Hetzner does not document when the deprecated field started lying, but the transition record pins it. All twelve ARM pairs flipped available at `09:27:31`. Twenty-one minutes earlier, at `09:06:25`, the same field reported cax11 in fsn1 and nbg1 **unavailable**. It cannot have been asserting ARM availability before a moment it was still denying it.

That also means the cax11 window of 2026-08-13 → 2026-08-17 09:06 is genuine and must be preserved — it arrived in two locations an hour apart, which is stock moving, not a data source changing:

```
45/1 cax11 fsn1   UP 2026-08-13 09:27:44
45/2 cax11 nbg1   UP 2026-08-13 10:34:03     ← an hour apart: real stock
45/1, 45/2      DOWN 2026-08-17 09:06:25     ← field still says "unavailable"
all 12 ARM pairs  UP 2026-08-17 09:27:31     ← one poll cycle: the fiction starts
```

An earlier cutoff would rewrite those two pairs from 2026-08-17 back to May and lose a real availability window.

The window must not be widened to catch more. It spans five days, and many x86 types legitimately flap inside it — cx33 in hel1 was last available 30 minutes before this was written. The ARM restriction in `findSuspectKeys` is what stops those being "repaired" to an earlier date.

## Why ARM only

Because that is where the corruption is, measured rather than assumed. Comparing the deprecated field against `/v1/server_types` across all **114 (server type × location) pairs**, twice on 2026-08-22, gives **12 disagreements, all ARM** — the same twelve both times.

The honest limit on that: it is a point-in-time check. It cannot rule out the deprecated field having been wrong about some other type at some earlier date, because the Analytics Engine transitions were themselves written from that field, so there is no independent record to compare against. What bounds the risk is that a corrupted `lastSeenAvailable` only *persists* for a pair that never becomes genuinely available again — anything that has flapped since has had its timestamp overwritten by real availability. Today the only pairs stuck unavailable with a recent timestamp are the twelve ARM ones.

## Things worth pushing back on

- **It writes to Durable Object storage.** Any failure leaves the matrix untouched and the flag unset, so the next alarm retries, but it is still a migration and not a pure read. Note it swallows its own errors by design, so a repair failure is logged but does not mark the poll failed or increment the alarm error metric.
- **It runs itself rather than being invoked.** The repair fires from the poll alarm, within a minute of deploy, and a failure is caught so it cannot fail the poll. A manual trigger would be preferable in principle, but is not available here: Durable Object storage is only reachable from inside the object, and the worker sets `workers_dev: false` with no routes, so it has no public URL. Offering one would mean adding an endpoint, a public URL, and authentication to production in order to avoid a one-shot migration — strictly more surface, permanently, to replace something that deletes itself.
- **It is deliberately temporary.** The module states where it becomes dead code: once `armLastSeenRepairV1` is set on the live Durable Object, this file, `repairArmLastSeen`, and its call in `alarm()` can all be deleted. Confirm from `wrangler tail`, which logs either "Repaired N ARM last-seen entries" on the run that does the work or "ARM last-seen repair: already-done" on every alarm after it. Nothing enforces the deletion.

## Ordering

This should land after #288, and is safe if it does not. Suspect entries are only identifiable once the poller reports the affected pairs as unavailable; before that the repair finds nothing. It therefore records itself as done only once it has actually run, rather than flagging on an empty result and retiring itself unused. Re-checking costs four storage reads and no Analytics Engine traffic; once the flag is set it is a single read per alarm.

## What it does not fix

Analytics Engine is append-only, so the phantom availability band from 2026-08-17 to the #288 deploy stays in the heatmap until it ages out of the 30-day view. Only the derived `lastSeenAvailable` timestamps are repairable.

## Verification

- 18 tests. The pure functions cover selection, recovery, UTC parsing of Analytics Engine's zone-less timestamps, and the case where nothing is recoverable. A follow-up commit extracts the orchestration into `runArmLastSeenRepair`, taking storage and the history query as dependencies, so the part that actually writes is testable without a live Durable Object: repaired, already-done, nothing-to-repair not flagging itself done, no-snapshot, a failed query leaving both matrix and flag untouched, one query per type rather than per pair, and the cax11 window the cutoff preserves.
- `worker`: 281 tests pass, `tsc --noEmit` clean, eslint and prettier clean.

